### PR TITLE
add compose docker setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,5 @@ jobs:
       with:
         version: 0.13.0
 
-    - name: Build
-      run: zig build
-
     - name: Run tests
       run: zig build test
-
-    - name: Run program
-      run: zig build run

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# ベースイメージにAlpine Linuxを使用
+FROM alpine:latest
+
+# Zigコンパイラをインストール
+RUN apk add --no-cache zig
+
+# 一般ユーザー 'appuser' を作成し、作業用ディレクトリを設定
+RUN addgroup -S appgroup && \
+  adduser -S appuser -G appgroup
+
+# 作業ディレクトリを作成し、所有者をappuserに設定
+RUN mkdir -p /app && chown -R appuser:appgroup /app
+
+# 作業ディレクトリを指定
+WORKDIR /app
+
+# ホスト側のファイルをコンテナ内にコピーし、appuserに所有権を設定
+COPY --chown=appuser:appgroup . .
+
+# 一般ユーザーに切り替え
+USER appuser
+
+CMD ["zig", "run", "src/main.zig"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  node1:
+    build: .
+    container_name: node1
+    ports:
+      - "3001:3000"
+    environment:
+      - NODE_ID=1
+  node2:
+    build: .
+    container_name: node2
+    ports:
+      - "3002:3000"
+    environment:
+      - NODE_ID=2
+  node3:
+    build: .
+    container_name: node3
+    ports:
+      - "3003:3000"
+    environment:
+      - NODE_ID=3

--- a/references/setup/Dockerfile
+++ b/references/setup/Dockerfile
@@ -1,0 +1,23 @@
+# ベースイメージにAlpine Linuxを使用
+FROM alpine:latest
+
+# Zigコンパイラをインストール
+RUN apk add --no-cache zig
+
+# 一般ユーザー 'appuser' を作成し、作業用ディレクトリを設定
+RUN addgroup -S appgroup && \
+  adduser -S appuser -G appgroup
+
+# 作業ディレクトリを作成し、所有者をappuserに設定
+RUN mkdir -p /app && chown -R appuser:appgroup /app
+
+# 作業ディレクトリを指定
+WORKDIR /app
+
+# ホスト側のファイルをコンテナ内にコピーし、appuserに所有権を設定
+COPY --chown=appuser:appgroup . .
+
+# 一般ユーザーに切り替え
+USER appuser
+
+CMD ["zig", "run", "src/main.zig"]

--- a/references/setup/build.zig
+++ b/references/setup/build.zig
@@ -1,0 +1,91 @@
+const std = @import("std");
+
+// Although this function looks imperative, note that its job is to
+// declaratively construct a build graph that will be executed by an external
+// runner.
+pub fn build(b: *std.Build) void {
+    // Standard target options allows the person running `zig build` to choose
+    // what target to build for. Here we do not override the defaults, which
+    // means any target is allowed, and the default is native. Other options
+    // for restricting supported target set are available.
+    const target = b.standardTargetOptions(.{});
+
+    // Standard optimization options allow the person running `zig build` to select
+    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall. Here we do not
+    // set a preferred release mode, allowing the user to decide how to optimize.
+    const optimize = b.standardOptimizeOption(.{});
+
+    const lib = b.addStaticLibrary(.{
+        .name = "setup",
+        // In this case the main source file is merely a path, however, in more
+        // complicated build scripts, this could be a generated file.
+        .root_source_file = b.path("src/root.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    // This declares intent for the library to be installed into the standard
+    // location when the user invokes the "install" step (the default step when
+    // running `zig build`).
+    b.installArtifact(lib);
+
+    const exe = b.addExecutable(.{
+        .name = "setup",
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    // This declares intent for the executable to be installed into the
+    // standard location when the user invokes the "install" step (the default
+    // step when running `zig build`).
+    b.installArtifact(exe);
+
+    // This *creates* a Run step in the build graph, to be executed when another
+    // step is evaluated that depends on it. The next line below will establish
+    // such a dependency.
+    const run_cmd = b.addRunArtifact(exe);
+
+    // By making the run step depend on the install step, it will be run from the
+    // installation directory rather than directly from within the cache directory.
+    // This is not necessary, however, if the application depends on other installed
+    // files, this ensures they will be present and in the expected location.
+    run_cmd.step.dependOn(b.getInstallStep());
+
+    // This allows the user to pass arguments to the application in the build
+    // command itself, like this: `zig build run -- arg1 arg2 etc`
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
+
+    // This creates a build step. It will be visible in the `zig build --help` menu,
+    // and can be selected like this: `zig build run`
+    // This will evaluate the `run` step rather than the default, which is "install".
+    const run_step = b.step("run", "Run the app");
+    run_step.dependOn(&run_cmd.step);
+
+    // Creates a step for unit testing. This only builds the test executable
+    // but does not run it.
+    const lib_unit_tests = b.addTest(.{
+        .root_source_file = b.path("src/root.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
+
+    const exe_unit_tests = b.addTest(.{
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const run_exe_unit_tests = b.addRunArtifact(exe_unit_tests);
+
+    // Similar to creating the run step earlier, this exposes a `test` step to
+    // the `zig build --help` menu, providing a way for the user to request
+    // running the unit tests.
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&run_lib_unit_tests.step);
+    test_step.dependOn(&run_exe_unit_tests.step);
+}

--- a/references/setup/build.zig.zon
+++ b/references/setup/build.zig.zon
@@ -1,0 +1,72 @@
+.{
+    // This is the default name used by packages depending on this one. For
+    // example, when a user runs `zig fetch --save <url>`, this field is used
+    // as the key in the `dependencies` table. Although the user can choose a
+    // different name, most users will stick with this provided value.
+    //
+    // It is redundant to include "zig" in this name because it is already
+    // within the Zig package namespace.
+    .name = "setup",
+
+    // This is a [Semantic Version](https://semver.org/).
+    // In a future version of Zig it will be used for package deduplication.
+    .version = "0.0.0",
+
+    // This field is optional.
+    // This is currently advisory only; Zig does not yet do anything
+    // with this value.
+    //.minimum_zig_version = "0.11.0",
+
+    // This field is optional.
+    // Each dependency must either provide a `url` and `hash`, or a `path`.
+    // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.
+    // Once all dependencies are fetched, `zig build` no longer requires
+    // internet connectivity.
+    .dependencies = .{
+        // See `zig fetch --save <url>` for a command-line interface for adding dependencies.
+        //.example = .{
+        //    // When updating this field to a new URL, be sure to delete the corresponding
+        //    // `hash`, otherwise you are communicating that you expect to find the old hash at
+        //    // the new URL.
+        //    .url = "https://example.com/foo.tar.gz",
+        //
+        //    // This is computed from the file contents of the directory of files that is
+        //    // obtained after fetching `url` and applying the inclusion rules given by
+        //    // `paths`.
+        //    //
+        //    // This field is the source of truth; packages do not come from a `url`; they
+        //    // come from a `hash`. `url` is just one of many possible mirrors for how to
+        //    // obtain a package matching this `hash`.
+        //    //
+        //    // Uses the [multihash](https://multiformats.io/multihash/) format.
+        //    .hash = "...",
+        //
+        //    // When this is provided, the package is found in a directory relative to the
+        //    // build root. In this case the package's hash is irrelevant and therefore not
+        //    // computed. This field and `url` are mutually exclusive.
+        //    .path = "foo",
+
+        //    // When this is set to `true`, a package is declared to be lazily
+        //    // fetched. This makes the dependency only get fetched if it is
+        //    // actually used.
+        //    .lazy = false,
+        //},
+    },
+
+    // Specifies the set of files and directories that are included in this package.
+    // Only files and directories listed here are included in the `hash` that
+    // is computed for this package. Only files listed here will remain on disk
+    // when using the zig package manager. As a rule of thumb, one should list
+    // files required for compilation plus any license(s).
+    // Paths are relative to the build root. Use the empty string (`""`) to refer to
+    // the build root itself.
+    // A directory listed here means that all files within, recursively, are included.
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+        // For example...
+        //"LICENSE",
+        //"README.md",
+    },
+}

--- a/references/setup/docker-compose.yml
+++ b/references/setup/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  node1:
+    build: .
+    container_name: node1
+    ports:
+      - "3001:3000"
+    environment:
+      - NODE_ID=1
+  node2:
+    build: .
+    container_name: node2
+    ports:
+      - "3002:3000"
+    environment:
+      - NODE_ID=2
+  node3:
+    build: .
+    container_name: node3
+    ports:
+      - "3003:3000"
+    environment:
+      - NODE_ID=3

--- a/references/setup/src/main.zig
+++ b/references/setup/src/main.zig
@@ -1,0 +1,6 @@
+const std = @import("std");
+
+pub fn main() !void {
+    const stdout = std.io.getStdOut().writer();
+    try stdout.print("Hello, {s}\n", .{"world"});
+}

--- a/references/setup/src/root.zig
+++ b/references/setup/src/root.zig
@@ -1,0 +1,10 @@
+const std = @import("std");
+const testing = std.testing;
+
+export fn add(a: i32, b: i32) i32 {
+    return a + b;
+}
+
+test "basic add functionality" {
+    try testing.expect(add(3, 7) == 10);
+}


### PR DESCRIPTION
This pull request includes significant changes to the Docker and Zig configuration files to improve the setup and build process. The changes include the addition of Docker and Docker Compose configurations, updates to Zig build files, and modifications to the CI workflow.

### Docker and Docker Compose Configuration:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R23): Added a new Dockerfile using Alpine Linux as the base image, installing the Zig compiler, and setting up a non-root user with appropriate permissions.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R1-R22): Introduced a Docker Compose file to define multiple services (`node1`, `node2`, and `node3`), each with its own container, ports, and environment variables.

### Zig Build and Configuration Files:

* [`references/setup/Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R23): Added a Dockerfile in the `references/setup` directory, similar to the main Dockerfile, to set up the Zig compiler and environment.
* [`references/setup/build.zig`](diffhunk://#diff-f9ffc6c002911b1f5f0bbe8c4cacc2137a8388cb785ce206b3b033dde5f05769R1-R91): Created a new Zig build script to define the build process, including target options, optimization options, and steps for building, running, and testing the project.
* [`references/setup/build.zig.zon`](diffhunk://#diff-a6647e1e75b40c4907709df90b1087a232f60691f5768284681c09a40d4949b8R1-R72): Added a Zig package configuration file to define the package name, version, dependencies, and included paths.

### CI Workflow:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL18-L25): Removed the build and run steps from the CI workflow, leaving only the test step to run Zig tests.