### PR TITLE
add section1 step1

### DIFF
--- a/references/section1/step1/Dockerfile
+++ b/references/section1/step1/Dockerfile
@@ -1,0 +1,23 @@
+# ベースイメージにAlpine Linuxを使用
+FROM alpine:latest
+
+# Zigコンパイラをインストール
+RUN apk add --no-cache zig
+
+# 一般ユーザー 'appuser' を作成し、作業用ディレクトリを設定
+RUN addgroup -S appgroup && \
+  adduser -S appuser -G appgroup
+
+# 作業ディレクトリを作成し、所有者をappuserに設定
+RUN mkdir -p /app && chown -R appuser:appgroup /app
+
+# 作業ディレクトリを指定
+WORKDIR /app
+
+# ホスト側のファイルをコンテナ内にコピーし、appuserに所有権を設定
+COPY --chown=appuser:appgroup . .
+
+# 一般ユーザーに切り替え
+USER appuser
+
+CMD ["zig", "build", "run"]

--- a/references/section1/step1/build.zig
+++ b/references/section1/step1/build.zig
@@ -1,0 +1,116 @@
+const std = @import("std");
+
+// Although this function looks imperative, note that its job is to
+// declaratively construct a build graph that will be executed by an external
+// runner.
+pub fn build(b: *std.Build) void {
+    // Standard target options allows the person running `zig build` to choose
+    // what target to build for. Here we do not override the defaults, which
+    // means any target is allowed, and the default is native. Other options
+    // for restricting supported target set are available.
+    const target = b.standardTargetOptions(.{});
+
+    // Standard optimization options allow the person running `zig build` to select
+    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall. Here we do not
+    // set a preferred release mode, allowing the user to decide how to optimize.
+    const optimize = b.standardOptimizeOption(.{});
+
+    // This creates a "module", which represents a collection of source files alongside
+    // some compilation options, such as optimization mode and linked system libraries.
+    // Every executable or library we compile will be based on one or more modules.
+    const lib_mod = b.createModule(.{
+        // `root_source_file` is the Zig "entry point" of the module. If a module
+        // only contains e.g. external object files, you can make this `null`.
+        // In this case the main source file is merely a path, however, in more
+        // complicated build scripts, this could be a generated file.
+        .root_source_file = b.path("src/root.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    // We will also create a module for our other entry point, 'main.zig'.
+    const exe_mod = b.createModule(.{
+        // `root_source_file` is the Zig "entry point" of the module. If a module
+        // only contains e.g. external object files, you can make this `null`.
+        // In this case the main source file is merely a path, however, in more
+        // complicated build scripts, this could be a generated file.
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    // Modules can depend on one another using the `std.Build.Module.addImport` function.
+    // This is what allows Zig source code to use `@import("foo")` where 'foo' is not a
+    // file path. In this case, we set up `exe_mod` to import `lib_mod`.
+    exe_mod.addImport("foo_lib", lib_mod);
+
+    // Now, we will create a static library based on the module we created above.
+    // This creates a `std.Build.Step.Compile`, which is the build step responsible
+    // for actually invoking the compiler.
+    const lib = b.addLibrary(.{
+        .linkage = .static,
+        .name = "foo",
+        .root_module = lib_mod,
+    });
+
+    // This declares intent for the library to be installed into the standard
+    // location when the user invokes the "install" step (the default step when
+    // running `zig build`).
+    b.installArtifact(lib);
+
+    // This creates another `std.Build.Step.Compile`, but this one builds an executable
+    // rather than a static library.
+    const exe = b.addExecutable(.{
+        .name = "foo",
+        .root_module = exe_mod,
+    });
+
+    // This declares intent for the executable to be installed into the
+    // standard location when the user invokes the "install" step (the default
+    // step when running `zig build`).
+    b.installArtifact(exe);
+
+    // This *creates* a Run step in the build graph, to be executed when another
+    // step is evaluated that depends on it. The next line below will establish
+    // such a dependency.
+    const run_cmd = b.addRunArtifact(exe);
+
+    // By making the run step depend on the install step, it will be run from the
+    // installation directory rather than directly from within the cache directory.
+    // This is not necessary, however, if the application depends on other installed
+    // files, this ensures they will be present and in the expected location.
+    run_cmd.step.dependOn(b.getInstallStep());
+
+    // This allows the user to pass arguments to the application in the build
+    // command itself, like this: `zig build run -- arg1 arg2 etc`
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
+
+    // This creates a build step. It will be visible in the `zig build --help` menu,
+    // and can be selected like this: `zig build run`
+    // This will evaluate the `run` step rather than the default, which is "install".
+    const run_step = b.step("run", "Run the app");
+    run_step.dependOn(&run_cmd.step);
+
+    // Creates a step for unit testing. This only builds the test executable
+    // but does not run it.
+    const lib_unit_tests = b.addTest(.{
+        .root_module = lib_mod,
+    });
+
+    const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
+
+    const exe_unit_tests = b.addTest(.{
+        .root_module = exe_mod,
+    });
+
+    const run_exe_unit_tests = b.addRunArtifact(exe_unit_tests);
+
+    // Similar to creating the run step earlier, this exposes a `test` step to
+    // the `zig build --help` menu, providing a way for the user to request
+    // running the unit tests.
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&run_lib_unit_tests.step);
+    test_step.dependOn(&run_exe_unit_tests.step);
+}

--- a/references/section1/step1/docker-compose.yml
+++ b/references/section1/step1/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  node1:
+    build: .
+    container_name: node1
+    ports:
+      - "3001:3000"
+    environment:
+      - NODE_ID=1
+  node2:
+    build: .
+    container_name: node2
+    ports:
+      - "3002:3000"
+    environment:
+      - NODE_ID=2
+  node3:
+    build: .
+    container_name: node3
+    ports:
+      - "3003:3000"
+    environment:
+      - NODE_ID=3

--- a/references/section1/step1/src/main.zig
+++ b/references/section1/step1/src/main.zig
@@ -1,0 +1,34 @@
+const std = @import("std");
+
+/// ブロックチェインの1ブロックを表す構造体
+/// - index: ブロック番号（u32）
+/// - timestamp: ブロック生成時のタイムスタンプ（u64）
+/// - prev_hash: 前ブロックのハッシュ（32バイトの固定長配列）
+/// - data: ブロックに含まれるデータ（可変長スライス）
+/// - hash: このブロックのハッシュ（SHA-256の結果、32バイト固定長配列）
+const Block = struct {
+    index: u32,
+    timestamp: u64,
+    prev_hash: [32]u8,
+    data: []const u8,
+    hash: [32]u8,
+};
+
+pub fn main() !void {
+    // 出力用ライター
+    const stdout = std.io.getStdOut().writer();
+
+    // ブロックのサンプルインスタンスを作成
+    const sample_block = Block{
+        .index = 1,
+        .timestamp = 1672531200, // 例: 適当なUNIXタイム
+        .prev_hash = [_]u8{0} ** 32, // とりあえず0で埋める
+        .data = "Hello, Zig Blockchain!", // 文字列をバイト列として扱う
+        .hash = [_]u8{0} ** 32, // まだハッシュ値計算はしない
+    };
+
+    // 作成したブロックの情報を表示
+    try stdout.print("Block index: {d}\n", .{sample_block.index});
+    try stdout.print("Timestamp  : {d}\n", .{sample_block.timestamp});
+    try stdout.print("Data       : {s}\n", .{sample_block.data});
+}

--- a/references/section1/step1/src/root.zig
+++ b/references/section1/step1/src/root.zig
@@ -1,0 +1,10 @@
+const std = @import("std");
+const testing = std.testing;
+
+export fn add(a: i32, b: i32) i32 {
+    return a + b;
+}
+
+test "basic add functionality" {
+    try testing.expect(add(3, 7) == 10);
+}


### PR DESCRIPTION
This pull request introduces several changes to set up a Zig project with Docker and Docker Compose, including configuration files and sample code for building and running a Zig application. The most important changes include the addition of a `Dockerfile`, a `docker-compose.yml` file, a build script in Zig, and sample Zig source files.

### Docker and Docker Compose Setup:
* [`references/section1/step1/Dockerfile`](diffhunk://#diff-1faaa45e7a517573a1bf42eb5e9c211b9c535b257584571e9730b379fb3fe521R1-R23): Added a Dockerfile to create a containerized environment using Alpine Linux, install the Zig compiler, create a non-root user, and set up the working directory.
* [`references/section1/step1/docker-compose.yml`](diffhunk://#diff-12f123f2dd88988f1d547da5849eadb44e2ce5723f926b9cb32e7ad219667793R1-R22): Added a Docker Compose file to define services for running multiple instances of the Zig application in separate containers.

### Zig Build Configuration:
* [`references/section1/step1/build.zig`](diffhunk://#diff-7ac38055ea1a5ea65a6ebde20d4333ad1924b8c1d2dbcc266c42a7fb62ff8300R1-R116): Added a build script in Zig to define the build process, including creating modules, building a static library and an executable, and setting up unit tests.

### Zig Source Files:
* [`references/section1/step1/src/main.zig`](diffhunk://#diff-649cb91659822ba41dca397f6225e85fba6f441bc71e174db5791a40f299f05cR1-R34): Added a sample Zig source file that defines a `Block` struct for a blockchain and a `main` function to create and print a sample block.
* [`references/section1/step1/src/root.zig`](diffhunk://#diff-14ac6df39367e6db0aaececf7f40695123ab2bf5be2527052add1b640cbac4bdR1-R10): Added a Zig source file with an `add` function and a basic unit test to verify its functionality.