### PR TITLE
fix zig version is not 0.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,35 @@
-# ベースイメージにAlpine Linuxを使用
+# ベースイメージに Alpine Linux を使用
 FROM alpine:latest
 
-# Zigコンパイラをインストール
-RUN apk add --no-cache zig
+# zig の公式バイナリをダウンロードするために必要なツールをインストール
+# xz パッケージを追加して tar が .tar.xz を解凍できるようにする
+RUN apk add --no-cache curl tar xz
 
-# 一般ユーザー 'appuser' を作成し、作業用ディレクトリを設定
+# Zig のバージョンを指定可能にするビルド引数（デフォルトは 0.14.0）
+ARG ZIG_VERSION=0.14.0
+# ここでは x86_64 用のバイナリを使用する例です
+ENV ZIG_DIST=zig-linux-x86_64-${ZIG_VERSION}
+ENV ZIG_VERSION=${ZIG_VERSION}
+
+# 指定された Zig のバージョンを公式サイトからダウンロードして解凍し、PATH に追加
+RUN curl -LO https://ziglang.org/download/${ZIG_VERSION}/${ZIG_DIST}.tar.xz && \
+  tar -xf ${ZIG_DIST}.tar.xz && \
+  rm ${ZIG_DIST}.tar.xz
+ENV PATH="/${ZIG_DIST}:${PATH}"
+
+# 一般ユーザー appuser を作成し、作業用ディレクトリを設定
 RUN addgroup -S appgroup && \
-  adduser -S appuser -G appgroup
+  adduser -S appuser -G appgroup && \
+  mkdir -p /app && chown -R appuser:appgroup /app
 
-# 作業ディレクトリを作成し、所有者をappuserに設定
-RUN mkdir -p /app && chown -R appuser:appgroup /app
-
-# 作業ディレクトリを指定
+# 作業ディレクトリを /app に設定
 WORKDIR /app
 
-# ホスト側のファイルをコンテナ内にコピーし、appuserに所有権を設定
+# ホスト側のファイルをコンテナ内にコピーし、所有者を appuser に設定
 COPY --chown=appuser:appgroup . .
 
 # 一般ユーザーに切り替え
 USER appuser
 
-CMD ["zig", "run", "src/main.zig"]
+# コンテナ起動時に Zig ビルドシステムを使って run を実行
+CMD ["zig", "build", "run"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   node1:
     build: .
+    platform: linux/amd64
     container_name: node1
     ports:
       - "3001:3000"
@@ -8,6 +9,7 @@ services:
       - NODE_ID=1
   node2:
     build: .
+    platform: linux/amd64
     container_name: node2
     ports:
       - "3002:3000"
@@ -15,6 +17,7 @@ services:
       - NODE_ID=2
   node3:
     build: .
+    platform: linux/amd64
     container_name: node3
     ports:
       - "3003:3000"

--- a/references/section1/step1/Dockerfile
+++ b/references/section1/step1/Dockerfile
@@ -1,23 +1,35 @@
-# ベースイメージにAlpine Linuxを使用
+# ベースイメージに Alpine Linux を使用
 FROM alpine:latest
 
-# Zigコンパイラをインストール
-RUN apk add --no-cache zig
+# zig の公式バイナリをダウンロードするために必要なツールをインストール
+# xz パッケージを追加して tar が .tar.xz を解凍できるようにする
+RUN apk add --no-cache curl tar xz
 
-# 一般ユーザー 'appuser' を作成し、作業用ディレクトリを設定
+# Zig のバージョンを指定可能にするビルド引数（デフォルトは 0.14.0）
+ARG ZIG_VERSION=0.14.0
+# ここでは x86_64 用のバイナリを使用する例です
+ENV ZIG_DIST=zig-linux-x86_64-${ZIG_VERSION}
+ENV ZIG_VERSION=${ZIG_VERSION}
+
+# 指定された Zig のバージョンを公式サイトからダウンロードして解凍し、PATH に追加
+RUN curl -LO https://ziglang.org/download/${ZIG_VERSION}/${ZIG_DIST}.tar.xz && \
+  tar -xf ${ZIG_DIST}.tar.xz && \
+  rm ${ZIG_DIST}.tar.xz
+ENV PATH="/${ZIG_DIST}:${PATH}"
+
+# 一般ユーザー appuser を作成し、作業用ディレクトリを設定
 RUN addgroup -S appgroup && \
-  adduser -S appuser -G appgroup
+  adduser -S appuser -G appgroup && \
+  mkdir -p /app && chown -R appuser:appgroup /app
 
-# 作業ディレクトリを作成し、所有者をappuserに設定
-RUN mkdir -p /app && chown -R appuser:appgroup /app
-
-# 作業ディレクトリを指定
+# 作業ディレクトリを /app に設定
 WORKDIR /app
 
-# ホスト側のファイルをコンテナ内にコピーし、appuserに所有権を設定
+# ホスト側のファイルをコンテナ内にコピーし、所有者を appuser に設定
 COPY --chown=appuser:appgroup . .
 
 # 一般ユーザーに切り替え
 USER appuser
 
+# コンテナ起動時に Zig ビルドシステムを使って run を実行
 CMD ["zig", "build", "run"]

--- a/references/section1/step1/build.zig
+++ b/references/section1/step1/build.zig
@@ -42,14 +42,14 @@ pub fn build(b: *std.Build) void {
     // Modules can depend on one another using the `std.Build.Module.addImport` function.
     // This is what allows Zig source code to use `@import("foo")` where 'foo' is not a
     // file path. In this case, we set up `exe_mod` to import `lib_mod`.
-    exe_mod.addImport("foo_lib", lib_mod);
+    exe_mod.addImport("step1_lib", lib_mod);
 
     // Now, we will create a static library based on the module we created above.
     // This creates a `std.Build.Step.Compile`, which is the build step responsible
     // for actually invoking the compiler.
     const lib = b.addLibrary(.{
         .linkage = .static,
-        .name = "foo",
+        .name = "step1",
         .root_module = lib_mod,
     });
 
@@ -61,7 +61,7 @@ pub fn build(b: *std.Build) void {
     // This creates another `std.Build.Step.Compile`, but this one builds an executable
     // rather than a static library.
     const exe = b.addExecutable(.{
-        .name = "foo",
+        .name = "step1",
         .root_module = exe_mod,
     });
 

--- a/references/section1/step1/docker-compose.yml
+++ b/references/section1/step1/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   node1:
     build: .
+    platform: linux/amd64
     container_name: node1
     ports:
       - "3001:3000"
@@ -8,6 +9,7 @@ services:
       - NODE_ID=1
   node2:
     build: .
+    platform: linux/amd64
     container_name: node2
     ports:
       - "3002:3000"
@@ -15,6 +17,7 @@ services:
       - NODE_ID=2
   node3:
     build: .
+    platform: linux/amd64
     container_name: node3
     ports:
       - "3003:3000"

--- a/references/section1/step1/src/root.zig
+++ b/references/section1/step1/src/root.zig
@@ -1,7 +1,10 @@
+//! By convention, root.zig is the root source file when making a library. If
+//! you are making an executable, the convention is to delete this file and
+//! start with main.zig instead.
 const std = @import("std");
 const testing = std.testing;
 
-export fn add(a: i32, b: i32) i32 {
+pub export fn add(a: i32, b: i32) i32 {
     return a + b;
 }
 

--- a/references/setup/Dockerfile
+++ b/references/setup/Dockerfile
@@ -1,23 +1,35 @@
-# ベースイメージにAlpine Linuxを使用
+# ベースイメージに Alpine Linux を使用
 FROM alpine:latest
 
-# Zigコンパイラをインストール
-RUN apk add --no-cache zig
+# zig の公式バイナリをダウンロードするために必要なツールをインストール
+# xz パッケージを追加して tar が .tar.xz を解凍できるようにする
+RUN apk add --no-cache curl tar xz
 
-# 一般ユーザー 'appuser' を作成し、作業用ディレクトリを設定
+# Zig のバージョンを指定可能にするビルド引数（デフォルトは 0.14.0）
+ARG ZIG_VERSION=0.14.0
+# ここでは x86_64 用のバイナリを使用する例です
+ENV ZIG_DIST=zig-linux-x86_64-${ZIG_VERSION}
+ENV ZIG_VERSION=${ZIG_VERSION}
+
+# 指定された Zig のバージョンを公式サイトからダウンロードして解凍し、PATH に追加
+RUN curl -LO https://ziglang.org/download/${ZIG_VERSION}/${ZIG_DIST}.tar.xz && \
+  tar -xf ${ZIG_DIST}.tar.xz && \
+  rm ${ZIG_DIST}.tar.xz
+ENV PATH="/${ZIG_DIST}:${PATH}"
+
+# 一般ユーザー appuser を作成し、作業用ディレクトリを設定
 RUN addgroup -S appgroup && \
-  adduser -S appuser -G appgroup
+  adduser -S appuser -G appgroup && \
+  mkdir -p /app && chown -R appuser:appgroup /app
 
-# 作業ディレクトリを作成し、所有者をappuserに設定
-RUN mkdir -p /app && chown -R appuser:appgroup /app
-
-# 作業ディレクトリを指定
+# 作業ディレクトリを /app に設定
 WORKDIR /app
 
-# ホスト側のファイルをコンテナ内にコピーし、appuserに所有権を設定
+# ホスト側のファイルをコンテナ内にコピーし、所有者を appuser に設定
 COPY --chown=appuser:appgroup . .
 
 # 一般ユーザーに切り替え
 USER appuser
 
+# コンテナ起動時に Zig ビルドシステムを使って run を実行
 CMD ["zig", "build", "run"]

--- a/references/setup/docker-compose.yml
+++ b/references/setup/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   node1:
     build: .
+    platform: linux/amd64
     container_name: node1
     ports:
       - "3001:3000"
@@ -8,6 +9,7 @@ services:
       - NODE_ID=1
   node2:
     build: .
+    platform: linux/amd64
     container_name: node2
     ports:
       - "3002:3000"
@@ -15,6 +17,7 @@ services:
       - NODE_ID=2
   node3:
     build: .
+    platform: linux/amd64
     container_name: node3
     ports:
       - "3003:3000"

--- a/references/setup/src/root.zig
+++ b/references/setup/src/root.zig
@@ -1,7 +1,10 @@
+//! By convention, root.zig is the root source file when making a library. If
+//! you are making an executable, the convention is to delete this file and
+//! start with main.zig instead.
 const std = @import("std");
 const testing = std.testing;
 
-export fn add(a: i32, b: i32) i32 {
+pub export fn add(a: i32, b: i32) i32 {
     return a + b;
 }
 


### PR DESCRIPTION
This pull request includes several changes to improve the Docker setup and build process for Zig projects. The most important changes include modifications to the `Dockerfile` to download the Zig compiler from the official site, updates to the `docker-compose.yml` file to specify the platform, and adjustments to the Zig build configuration.

### Docker setup improvements:
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L4-R35): Replaced the installation of the Zig compiler with a process to download the official Zig binary, added necessary tools (`curl`, `tar`, `xz`), and made the Zig version configurable via build arguments.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R4-R20): Added the `platform: linux/amd64` specification for each service to ensure compatibility.

### Zig build configuration updates:
* [`build.zig`](diffhunk://#diff-7ac38055ea1a5ea65a6ebde20d4333ad1924b8c1d2dbcc266c42a7fb62ff8300L45-R52): Updated module and executable names from "foo" to "step1" to better reflect the project structure. [[1]](diffhunk://#diff-7ac38055ea1a5ea65a6ebde20d4333ad1924b8c1d2dbcc266c42a7fb62ff8300L45-R52) [[2]](diffhunk://#diff-7ac38055ea1a5ea65a6ebde20d4333ad1924b8c1d2dbcc266c42a7fb62ff8300L64-R64)
* [`root.zig`](diffhunk://#diff-14ac6df39367e6db0aaececf7f40695123ab2bf5be2527052add1b640cbac4bdR1-R7): Changed the visibility of the `add` function to `pub` to ensure it is accessible as part of the library's public API.

These changes ensure a more robust and flexible build environment, improve compatibility across different platforms, and align the project structure with best practices.