### PR TITLE
refactor error type

### DIFF
--- a/references/chapter5/step3/src/main.zig
+++ b/references/chapter5/step3/src/main.zig
@@ -3,6 +3,13 @@ const crypto = std.crypto.hash;
 const Sha256 = crypto.sha2.Sha256;
 const DIFFICULTY: u8 = 1;
 
+pub const ChainError = error{
+    InvalidHexLength,
+    InvalidHexChar,
+    InvalidFormat,
+};
+
+
 //------------------------------------------------------------------------------
 // デバッグ出力関連
 //------------------------------------------------------------------------------
@@ -338,11 +345,11 @@ const SendHandler = struct {
 
 /// hexDecode: 16進文字列をバイナリへ (返り値: 実際に変換できたバイト数)
 fn hexDecode(src: []const u8, dst: *[256]u8) !usize {
-    if (src.len % 2 != 0) return error.InvalidHexLength;
+    if (src.len % 2 != 0) return ChainError.InvalidHexLength;
     var i: usize = 0;
     while (i < src.len) : (i += 2) {
-        const hi = parseHexDigit(src[i]) catch return error.InvalidHexChar;
-        const lo = parseHexDigit(src[i + 1]) catch return error.InvalidHexChar;
+        const hi = parseHexDigit(src[i]) catch return ChainError.InvalidHexChar;
+        const lo = parseHexDigit(src[i + 1]) catch return ChainError.InvalidHexChar;
         dst[i / 2] = (hi << 4) | lo;
     }
     return src.len / 2;
@@ -366,7 +373,7 @@ fn parseBlockJson(json_slice: []const u8) !Block {
     // getType() を使わずに、switch でパターンマッチする
     const obj = switch (root_value) {
         .object => |o| o,
-        else => return error.InvalidFormat,
+        else => return ChainError.InvalidFormat,
     };
 
     // ブロック構造体を一旦デフォルト初期化


### PR DESCRIPTION
This pull request includes changes to improve error handling in the `references/chapter5/step3/src/main.zig` file by introducing a new `ChainError` type and updating the error returns to use this new type.

Improvements to error handling:

* Added a new `ChainError` type with `InvalidHexLength`, `InvalidHexChar`, and `InvalidFormat` errors. (`[references/chapter5/step3/src/main.zigR6-R12](diffhunk://#diff-0411a031ca78a563a353c20c91e2cfdd19babfcec02ffb7ca092f4ff7734ef25R6-R12)`)
* Updated the `hexDecode` function to return `ChainError.InvalidHexLength` and `ChainError.InvalidHexChar` instead of the previous error types. (`[references/chapter5/step3/src/main.zigL341-R352](diffhunk://#diff-0411a031ca78a563a353c20c91e2cfdd19babfcec02ffb7ca092f4ff7734ef25L341-R352)`)
* Modified the `parseBlockJson` function to return `ChainError.InvalidFormat` instead of the previous error type. (`[references/chapter5/step3/src/main.zigL369-R376](diffhunk://#diff-0411a031ca78a563a353c20c91e2cfdd19babfcec02ffb7ca092f4ff7734ef25L369-R376)`)