### PR TITLE
add debug log

### DIFF
--- a/references/chapter5/step3/src/main.zig
+++ b/references/chapter5/step3/src/main.zig
@@ -488,8 +488,11 @@ fn parseHexDigit(c: u8) !u8 {
 }
 
 fn parseBlockJson(json_slice: []const u8) !Block {
+    std.log.info("parseBlockJson start", .{});
     const block_allocator = std.heap.page_allocator;
+    std.log.info("parseBlockJson start parsed", .{});
     const parsed = try std.json.parseFromSlice(std.json.Value, block_allocator, json_slice, .{});
+    std.log.info("parseBlockJson end parsed", .{});
     defer parsed.deinit();
     const root_value = parsed.value;
 
@@ -507,7 +510,7 @@ fn parseBlockJson(json_slice: []const u8) !Block {
         .data = "P2P Received Block",
         .hash = [_]u8{0} ** 32,
     };
-
+    std.log.info("parseBlockJson start parser", .{});
     // index の読み込み
     if (obj.get("index")) |idx_val| {
         const idx_num: i64 = switch (idx_val) {
@@ -648,7 +651,7 @@ fn parseBlockJson(json_slice: []const u8) !Block {
                     }
                     std.log.info("Transactions field is directly an array. end", .{});
                 }
-                std.log.info("565 Transactions field is directly an array. end", .{});
+                std.log.info("565 Transactions field is directly an array. end transactions={any}", .{b.transactions});
             },
             .string => {
                 std.log.info("Transactions field is a string. Value: {s}", .{tx_val.string});
@@ -946,19 +949,4 @@ test "ブロック改ざん検出テスト" {
 
     // 改ざん前後のハッシュが異なることを期待
     try std.testing.expect(!std.mem.eql(u8, originalHash[0..], tamperedHash[0..]));
-}
-
-test "json parse with strings" {
-    const User = struct { name: []u8, age: u16 };
-    const allocator = std.testing.allocator;
-
-    const parsed = try std.json.parseFromSlice(User, allocator,
-        \\{ "name": "Joe", "age": 25 }
-    , .{});
-    defer parsed.deinit();
-
-    const user = parsed.value;
-
-    try std.testing.expect(std.mem.eql(u8, user.name, "Joe"));
-    try std.testing.expect(user.age == 25);
 }


### PR DESCRIPTION
This pull request includes several changes to the `references/chapter5/step3/src/main.zig` file to improve logging and remove an unnecessary test.

Enhancements to logging:

* Added multiple `std.log.info` statements to the `parseBlockJson` function to log the start and end of parsing, as well as specific points within the parsing process. [[1]](diffhunk://#diff-0411a031ca78a563a353c20c91e2cfdd19babfcec02ffb7ca092f4ff7734ef25R491-R495) [[2]](diffhunk://#diff-0411a031ca78a563a353c20c91e2cfdd19babfcec02ffb7ca092f4ff7734ef25L510-R513) [[3]](diffhunk://#diff-0411a031ca78a563a353c20c91e2cfdd19babfcec02ffb7ca092f4ff7734ef25L651-R654)

Removal of unnecessary test:

* Removed the `test "json parse with strings"` test case, which was parsing a JSON string into a `User` struct and validating its fields.