### PR TITLE
add badge for repo size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+<!-- textlint-enable ja-technical-writing/sentence-length -->
+![GitHub last commit (by committer)](https://img.shields.io/github/last-commit/susumutomita/BlockChain)
+![GitHub top language](https://img.shields.io/github/languages/top/susumutomita/BlockChain)
+![GitHub pull requests](https://img.shields.io/github/issues-pr/susumutomita/BlockChain)
+![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/susumutomita/BlockChain)
+![GitHub repo size](https://img.shields.io/github/repo-size/susumutomita/BlockChain)
+[![Zig CI](https://github.com/susumutomita/BlockChain/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/susumutomita/BlockChain/actions/workflows/ci.yml)
+<!-- textlint-enable ja-technical-writing/sentence-length -->
+
 # Zig Simple Blockchain
 
 シンプルなブロックチェーンの Zig 言語による実装です。


### PR DESCRIPTION
This pull request includes updates to the `README.md` file to enhance its presentation and provide more information about the repository. The most important changes are the addition of various GitHub badges to display repository statistics and status.

Enhancements to `README.md`:

* Added a badge to show the date of the last commit.
* Added a badge to display the top programming language used in the repository.
* Added a badge to indicate the number of open pull requests.
* Added a badge to show the total code size in bytes.
* Added a badge to display the total repository size.
* Added a badge for the CI status from GitHub Actions.