### PR TITLE
bugfix hash not incremented

### DIFF
--- a/references/chapter5/src/blockchain.zig
+++ b/references/chapter5/src/blockchain.zig
@@ -6,36 +6,59 @@ const logger = @import("logger.zig");
 const utils = @import("utils.zig");
 
 //------------------------------------------------------------------------------
-// ハッシュ計算とPoWマイニング
+// ハッシュ計算とマイニング処理
 //------------------------------------------------------------------------------
+//
+// calculateHash 関数では、ブロック内の各フィールドを連結して
+// SHA-256 のハッシュを計算します。
+// mineBlock 関数は、nonce をインクリメントしながら
+// meetsDifficulty による難易度チェックをパスするハッシュを探します。
 
+/// calculateHash:
+/// 指定されたブロックの各フィールドをバイト列に変換し、
+/// その連結結果から SHA-256 ハッシュを計算して返す関数。
 pub fn calculateHash(block: *const types.Block) [32]u8 {
     var hasher = Sha256.init(.{});
 
-    // index
+    // nonce の値をバイト列に変換(8バイト)し、デバッグ用に出力
+    const nonce_bytes = utils.toBytesU64(block.nonce);
+    logger.debugLog("nonce bytes: ", .{});
+    if (comptime logger.debug_logging) {
+        for (nonce_bytes) |byte| {
+            std.debug.print("{x:0>2},", .{byte});
+        }
+        std.debug.print("\n", .{});
+    }
+
+    // ブロック番号 (u32) をバイト列に変換して追加
     hasher.update(utils.toBytes(u32, block.index));
-    // timestamp
+    // タイムスタンプ (u64) をバイト列に変換して追加
     hasher.update(utils.toBytes(u64, block.timestamp));
-    // nonce
-    hasher.update(utils.toBytes(u64, block.nonce));
-    // prev_hash
+    // nonce のバイト列を追加
+    hasher.update(nonce_bytes[0..]);
+    // 前ブロックのハッシュ(32バイト)を追加
     hasher.update(&block.prev_hash);
 
-    // transactions
+    // すべてのトランザクションについて、各フィールドを追加
     for (block.transactions.items) |tx| {
         hasher.update(tx.sender);
         hasher.update(tx.receiver);
-        hasher.update(utils.toBytes(u64, tx.amount));
+        const amount_bytes = utils.toBytesU64(tx.amount);
+        hasher.update(&amount_bytes);
     }
-
-    // data
+    // 追加データをハッシュに追加
     hasher.update(block.data);
 
-    const result = hasher.finalResult();
-    return result;
+    // 最終的なハッシュ値を計算
+    const hash = hasher.finalResult();
+    logger.debugLog("nonce: {d}, hash: {x}\n", .{ block.nonce, hash });
+    return hash;
 }
 
+/// meetsDifficulty:
+/// ハッシュ値の先頭 'difficulty' バイトがすべて 0 であれば true を返す。
 pub fn meetsDifficulty(hash: [32]u8, difficulty: u8) bool {
+    // difficulty が 32 を超える場合は 32 に丸める
     const limit = if (difficulty <= 32) difficulty else 32;
     for (hash[0..limit]) |byte| {
         if (byte != 0) return false;
@@ -43,10 +66,12 @@ pub fn meetsDifficulty(hash: [32]u8, difficulty: u8) bool {
     return true;
 }
 
+/// mineBlock:
+/// 指定された難易度を満たすハッシュが得られるまで、
+/// nonce の値を増やしながらハッシュ計算を繰り返す関数。
 pub fn mineBlock(block: *types.Block, difficulty: u8) void {
     while (true) {
         const new_hash = calculateHash(block);
-        logger.debugLog("Hash: {x}\n", .{new_hash});
         if (meetsDifficulty(new_hash, difficulty)) {
             block.hash = new_hash;
             break;

--- a/references/chapter5/src/logger.zig
+++ b/references/chapter5/src/logger.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-pub const debug_logging = true;
+pub const debug_logging = false;
 
 /// debugLog:
 /// デバッグログを出力するためのヘルパー関数です。

--- a/references/chapter5/src/main.zig
+++ b/references/chapter5/src/main.zig
@@ -45,7 +45,6 @@ pub fn main() !void {
     // 3. 初期ハッシュを計算
     genesis_block.hash = blockchain.calculateHash(&genesis_block);
     // 4. マイニング(難易度=1)
-    try stdout.print("Start Minig: {d}\n", .{genesis_block.index});
     blockchain.mineBlock(&genesis_block, 1);
 
     // 5. 結果を表示

--- a/references/chapter5/src/utils.zig
+++ b/references/chapter5/src/utils.zig
@@ -15,17 +15,17 @@ pub fn debugLog(comptime format: []const u8, args: anytype) void {
 // ヘルパー関数
 //------------------------------------------------------------------------------
 
-fn truncateU32ToU8(x: u32) u8 {
+pub fn truncateU32ToU8(x: u32) u8 {
     if (x > 0xff) @panic("u32 out of u8 range");
     return @truncate(x);
 }
 
-fn truncateU64ToU8(x: u64) u8 {
+pub fn truncateU64ToU8(x: u64) u8 {
     if (x > 0xff) @panic("u64 out of u8 range");
     return @truncate(x);
 }
 
-fn toBytesU32(value: u32) [4]u8 {
+pub fn toBytesU32(value: u32) [4]u8 {
     var buf: [4]u8 = undefined;
     buf[0] = truncateU32ToU8(value & 0xff);
     buf[1] = truncateU32ToU8((value >> 8) & 0xff);
@@ -34,7 +34,7 @@ fn toBytesU32(value: u32) [4]u8 {
     return buf;
 }
 
-fn toBytesU64(value: u64) [8]u8 {
+pub fn toBytesU64(value: u64) [8]u8 {
     var buf: [8]u8 = undefined;
     buf[0] = truncateU64ToU8(value & 0xff);
     buf[1] = truncateU64ToU8((value >> 8) & 0xff);


### PR DESCRIPTION
This pull request includes several updates to the blockchain implementation in `references/chapter5/src`. The changes focus on improving the hash calculation and mining process, modifying debug logging, and making utility functions public. The most important changes are summarized below:

Improvements to hash calculation and mining:

* [`references/chapter5/src/blockchain.zig`](diffhunk://#diff-3d5ede01a38ecf095c10fb01d6873e92194d7227d9c0c57d8f603a156e9e232dL9-L49): Added detailed comments and debug logging to the `calculateHash` function, and updated the `mineBlock` function to log the nonce and hash values during mining.

Debug logging modifications:

* [`references/chapter5/src/logger.zig`](diffhunk://#diff-22a380e9ea39ddadc2232e4893a44a6c381f81c709ca7e84fab6c661b4ae1471L3-R3): Changed the `debug_logging` constant to `false` to disable debug logging by default.
* [`references/chapter5/src/main.zig`](diffhunk://#diff-6109c16e42194f32cdc7c1e488e819f8cf94c3a48e0cfd047d5efc901dcbdf83L48): Removed a debug print statement from the `main` function to clean up the console output.

Utility functions updates:

* [`references/chapter5/src/utils.zig`](diffhunk://#diff-ff0a943122e6db11ea886832109724cac723befc97fa92dd83dcfd8c69a09dc0L18-R28): Made several utility functions (`truncateU32ToU8`, `truncateU64ToU8`, `toBytesU32`, and `toBytesU64`) public to allow their use in other modules. [[1]](diffhunk://#diff-ff0a943122e6db11ea886832109724cac723befc97fa92dd83dcfd8c69a09dc0L18-R28) [[2]](diffhunk://#diff-ff0a943122e6db11ea886832109724cac723befc97fa92dd83dcfd8c69a09dc0L37-R37)