### PR TITLE
split peer struct

### DIFF
--- a/references/chapter7/src/blockchain.zig
+++ b/references/chapter7/src/blockchain.zig
@@ -108,11 +108,6 @@ pub fn addBlock(new_block: types.Block) void {
     std.log.info("Added new block index={d}, nonce={d}, hash={x}", .{ new_block.index, new_block.nonce, new_block.hash });
 }
 
-pub const Peer = struct {
-    address: std.net.Address,
-    stream: std.net.Stream,
-};
-
 pub fn sendBlock(block: types.Block, remote_addr: std.net.Address) !void {
     const json_data = parser.serializeBlock(block) catch |err| {
         std.debug.print("Serialize error: {any}\n", .{err});
@@ -194,14 +189,14 @@ pub const ConnHandler = struct {
 // クライアント処理
 //--------------------------------------
 pub const ClientHandler = struct {
-    pub fn run(peer: Peer) !void {
+    pub fn run(peer: types.Peer) !void {
         // クライアントはローカルに Genesis ブロックを保持（本来はサーバーから同期する）
         var lastBlock = try createTestGenesisBlock(std.heap.page_allocator);
         clientSendLoop(peer, &lastBlock) catch unreachable;
     }
 };
 
-fn clientSendLoop(peer: Peer, lastBlock: *types.Block) !void {
+fn clientSendLoop(peer: types.Peer, lastBlock: *types.Block) !void {
     var stdin = std.io.getStdIn();
     var reader = stdin.reader();
     var line_buffer: [256]u8 = undefined;

--- a/references/chapter7/src/main.zig
+++ b/references/chapter7/src/main.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const blockchain = @import("blockchain.zig");
+const types = @import("types.zig");
 const parser = @import("parser.zig");
 
 //------------------------------------------------------------------------------
@@ -50,7 +51,7 @@ pub fn main() !void {
         std.log.info("Connecting to {s}:{d}...", .{ host_str, port_num });
         const remote_addr = try std.net.Address.resolveIp(host_str, port_num);
         var socket = try std.net.tcpConnectToAddress(remote_addr);
-        const peer = blockchain.Peer{
+        const peer = types.Peer{
             .address = remote_addr,
             .stream = socket,
         };

--- a/references/chapter7/src/types.zig
+++ b/references/chapter7/src/types.zig
@@ -1,21 +1,29 @@
 const std = @import("std");
 
-// Transaction 構造体
-// ブロックチェーン上の「取引」を表現します。
+//------------------------------------------------------------------------------
+// データ構造
+//------------------------------------------------------------------------------
 pub const Transaction = struct {
-    sender: []const u8, // 送信者のアドレスまたは識別子(文字列)
-    receiver: []const u8, // 受信者のアドレスまたは識別子(文字列)
-    amount: u64, // 取引金額(符号なし64ビット整数)
+    sender: []const u8,
+    receiver: []const u8,
+    amount: u64,
 };
 
-// Block 構造体
-// ブロックチェーン上の「ブロック」を表現します。
 pub const Block = struct {
-    index: u32, // ブロック番号(0から始まる連番)
-    timestamp: u64, // ブロック生成時のUNIXタイムスタンプ
-    prev_hash: [32]u8, // 前のブロックのハッシュ(32バイト固定)
-    transactions: std.ArrayList(Transaction), // ブロック内の複数の取引を保持する動的配列
-    nonce: u64, // Proof of Work (PoW) 採掘用のnonce値
-    data: []const u8, // 任意の追加データ(文字列など)
-    hash: [32]u8, // このブロックのSHA-256ハッシュ(32バイト固定)
+    index: u32,
+    timestamp: u64,
+    prev_hash: [32]u8,
+    transactions: std.ArrayList(Transaction),
+    nonce: u64,
+    data: []const u8,
+    hash: [32]u8,
+};
+
+//------------------------------------------------------------------------------
+// Peer 構造体
+// ネットワーク上のピアを表現します。
+// ピアは、アドレスとストリームを持ちます。
+pub const Peer = struct {
+    address: std.net.Address,
+    stream: std.net.Stream,
 };


### PR DESCRIPTION
This pull request includes changes to the `references/chapter7` directory to refactor and improve the code structure by moving the `Peer` struct to the `types.zig` file and updating the corresponding references. The most important changes include removing the `Peer` struct from `blockchain.zig`, updating function signatures to use `types.Peer`, and adding the necessary import statements.

Refactoring and code improvements:

* [`references/chapter7/src/blockchain.zig`](diffhunk://#diff-11d9f70414aa09564193c98e074475fee7bad7d95737a96912924832ca69eb3fL111-L115): Removed the `Peer` struct and updated function signatures to use `types.Peer` instead. [[1]](diffhunk://#diff-11d9f70414aa09564193c98e074475fee7bad7d95737a96912924832ca69eb3fL111-L115) [[2]](diffhunk://#diff-11d9f70414aa09564193c98e074475fee7bad7d95737a96912924832ca69eb3fL197-R199)
* [`references/chapter7/src/main.zig`](diffhunk://#diff-32617c5979008ab4531f03cf1b008ec2a308d1e6a951ffda01d72ce6d5515cd8R3): Added the import statement for `types.zig` and updated the creation of the `peer` instance to use `types.Peer`. [[1]](diffhunk://#diff-32617c5979008ab4531f03cf1b008ec2a308d1e6a951ffda01d72ce6d5515cd8R3) [[2]](diffhunk://#diff-32617c5979008ab4531f03cf1b008ec2a308d1e6a951ffda01d72ce6d5515cd8L53-R54)
* [`references/chapter7/src/types.zig`](diffhunk://#diff-cf5e56a0eee8c409ee2c26ac3b625b4330b8069726a7544220a436e261d3bca8L3-R28): Added the `Peer` struct definition and refactored the existing `Transaction` and `Block` struct comments for better readability.