### PR TITLE
remove debug log from util

### DIFF
--- a/references/chapter5/src/utils.zig
+++ b/references/chapter5/src/utils.zig
@@ -1,15 +1,5 @@
 const std = @import("std");
 
-/// デバッグログフラグ
-pub const debug_logging = false;
-
-/// デバッグログ
-pub fn debugLog(comptime format: []const u8, args: anytype) void {
-    if (comptime debug_logging) {
-        std.debug.print(format, args);
-    }
-}
-
 //------------------------------------------------------------------------------
 // ヘルパー関数
 //------------------------------------------------------------------------------


### PR DESCRIPTION
This pull request includes a removal of the debug logging utility from the `references/chapter5/src/utils.zig` file. The most important change is the deletion of the `debug_logging` constant and the `debugLog` function.

Codebase simplification:

* [`references/chapter5/src/utils.zig`](diffhunk://#diff-ff0a943122e6db11ea886832109724cac723befc97fa92dd83dcfd8c69a09dc0L3-L12): Removed the `debug_logging` constant and the `debugLog` function, which were used for conditional debug logging.