### PR TITLE
remove debug log from util

### DIFF
--- a/references/chapter7/src/utils.zig
+++ b/references/chapter7/src/utils.zig
@@ -1,15 +1,5 @@
 const std = @import("std");
 
-pub const debug_logging = false;
-
-/// debugLog:
-/// デバッグログを出力するためのヘルパー関数です。
-/// ※ debug_logging が true の場合のみ std.debug.print を呼び出します。
-pub fn debugLog(comptime format: []const u8, args: anytype) void {
-    if (comptime debug_logging) {
-        std.debug.print(format, args);
-    }
-}
 
 /// truncateU32ToU8:
 /// u32 の値を u8 に変換(値が 0xff を超えるとエラー)


### PR DESCRIPTION
This pull request includes a significant change to the `references/chapter7/src/utils.zig` file, specifically the removal of the debug logging functionality.

Codebase simplification:

* Removed the `debug_logging` constant and the `debugLog` function, which were used for conditional debug logging. This simplifies the code by eliminating unused or unnecessary debugging infrastructure.