### PR TITLE
use same name in chapter5

### DIFF
--- a/references/chapter7/src/utils.zig
+++ b/references/chapter7/src/utils.zig
@@ -1,53 +1,42 @@
 const std = @import("std");
 
+//------------------------------------------------------------------------------
+// ヘルパー関数
+//------------------------------------------------------------------------------
 
-/// truncateU32ToU8:
-/// u32 の値を u8 に変換(値が 0xff を超えるとエラー)
 pub fn truncateU32ToU8(x: u32) u8 {
-    if (x > 0xff) {
-        @panic("u32 value out of u8 range");
-    }
+    if (x > 0xff) @panic("u32 out of u8 range");
     return @truncate(x);
 }
 
-/// truncateU64ToU8:
-/// u64 の値を u8 に変換(値が 0xff を超えるとエラー)
 pub fn truncateU64ToU8(x: u64) u8 {
-    if (x > 0xff) {
-        @panic("u64 value out of u8 range");
-    }
+    if (x > 0xff) @panic("u64 out of u8 range");
     return @truncate(x);
 }
 
-/// toBytesU32:
-/// u32 の値をリトルエンディアンの 4 バイト配列に変換して返す。
 pub fn toBytesU32(value: u32) [4]u8 {
-    var bytes: [4]u8 = undefined;
-    bytes[0] = truncateU32ToU8(value & 0xff);
-    bytes[1] = truncateU32ToU8((value >> 8) & 0xff);
-    bytes[2] = truncateU32ToU8((value >> 16) & 0xff);
-    bytes[3] = truncateU32ToU8((value >> 24) & 0xff);
-    return bytes;
+    var buf: [4]u8 = undefined;
+    buf[0] = truncateU32ToU8(value & 0xff);
+    buf[1] = truncateU32ToU8((value >> 8) & 0xff);
+    buf[2] = truncateU32ToU8((value >> 16) & 0xff);
+    buf[3] = truncateU32ToU8((value >> 24) & 0xff);
+    return buf;
 }
 
-/// toBytesU64:
-/// u64 の値をリトルエンディアンの 8 バイト配列に変換して返す。
 pub fn toBytesU64(value: u64) [8]u8 {
-    var bytes: [8]u8 = undefined;
-    bytes[0] = truncateU64ToU8(value & 0xff);
-    bytes[1] = truncateU64ToU8((value >> 8) & 0xff);
-    bytes[2] = truncateU64ToU8((value >> 16) & 0xff);
-    bytes[3] = truncateU64ToU8((value >> 24) & 0xff);
-    bytes[4] = truncateU64ToU8((value >> 32) & 0xff);
-    bytes[5] = truncateU64ToU8((value >> 40) & 0xff);
-    bytes[6] = truncateU64ToU8((value >> 48) & 0xff);
-    bytes[7] = truncateU64ToU8((value >> 56) & 0xff);
-    return bytes;
+    var buf: [8]u8 = undefined;
+    buf[0] = truncateU64ToU8(value & 0xff);
+    buf[1] = truncateU64ToU8((value >> 8) & 0xff);
+    buf[2] = truncateU64ToU8((value >> 16) & 0xff);
+    buf[3] = truncateU64ToU8((value >> 24) & 0xff);
+    buf[4] = truncateU64ToU8((value >> 32) & 0xff);
+    buf[5] = truncateU64ToU8((value >> 40) & 0xff);
+    buf[6] = truncateU64ToU8((value >> 48) & 0xff);
+    buf[7] = truncateU64ToU8((value >> 56) & 0xff);
+    return buf;
 }
 
-/// toBytes:
-/// 任意の型 T の値をそのメモリ表現に基づいてバイト列(スライス)に変換する。
-/// u32, u64 の場合は専用の関数を呼び出し、それ以外は @bitCast で固定長配列に変換します。
+// publicにする: main.zigから呼べるようにする
 pub fn toBytes(comptime T: type, value: T) []const u8 {
     if (T == u32) {
         return toBytesU32(@as(u32, value))[0..];


### PR DESCRIPTION
This pull request includes a few changes to the `references/chapter7/src/utils.zig` file, mainly focusing on code simplification and minor improvements.

Code simplification:

* Simplified the `truncateU32ToU8` and `truncateU64ToU8` functions by removing unnecessary braces around the `@panic` statements.
* Replaced variable names `bytes` with `buf` in the `toBytesU32` and `toBytesU64` functions for consistency.

Minor improvements:

* Added a comment section header for helper functions to improve code readability.