### PR TITLE
add peer block

### DIFF
--- a/references/chapter8/src/blockchain.zig
+++ b/references/chapter8/src/blockchain.zig
@@ -7,8 +7,8 @@ const utils = @import("utils.zig");
 const chainError = @import("errors.zig").ChainError;
 const parser = @import("parser.zig");
 const DIFFICULTY: u8 = 2;
-var chain_store = std.ArrayList(types.Block).init(std.heap.page_allocator);
-var peer_list = std.ArrayList(types.Peer).init(std.heap.page_allocator);
+pub var chain_store = std.ArrayList(types.Block).init(std.heap.page_allocator);
+pub var peer_list = std.ArrayList(types.Peer).init(std.heap.page_allocator);
 
 //------------------------------------------------------------------------------
 // ハッシュ計算とマイニング処理

--- a/references/chapter8/src/main.zig
+++ b/references/chapter8/src/main.zig
@@ -3,75 +3,124 @@ const blockchain = @import("blockchain.zig");
 const types = @import("types.zig");
 const parser = @import("parser.zig");
 
-//------------------------------------------------------------------------------
-// メイン処理およびテスト実行
-//------------------------------------------------------------------------------
-//
-// main 関数では、以下の手順を実行しています：
-// 1. ジェネシスブロック(最初のブロック)を初期化。
-// 2. 取引リスト(トランザクション)の初期化と追加。
-// 3. ブロックのハッシュを計算し、指定難易度に到達するまで nonce を探索(採掘)。
-// 4. 最終的なブロック情報を標準出力に表示。
 pub fn main() !void {
     const gpa = std.heap.page_allocator;
     const args = try std.process.argsAlloc(gpa);
     defer std.process.argsFree(gpa, args);
 
-    // 引数: <port> [peer1] [peer2] ...
     if (args.len < 2) {
-        std.log.err("Usage: {s} <port> [host:port]...", .{args[0]});
+        std.log.err("Usage: {s} <port> [peer...]", .{args[0]});
         return;
     }
 
     const self_port = try std.fmt.parseInt(u16, args[1], 10);
-    const known_peers = args[2..]; // [][]u8
+    const known_peers = args[2..];
 
-    // ----- リスナー起動 -----
+    // ── リスナー起動 ───────────────────────
     var addr = try std.net.Address.resolveIp("0.0.0.0", self_port);
-    var listener = try addr.listen(.{});
-    _ = try std.Thread.spawn(.{}, listenLoop, .{&listener});
-    std.log.info("Listening on 0.0.0.0:{d}", .{self_port});
+    var servo = try addr.listen(.{});
+    std.log.info("listen 0.0.0.0:{d}", .{self_port});
+    _ = try std.Thread.spawn(.{}, acceptLoop, .{&servo});
 
-    for (known_peers) |peer_str| {
-        const peer_addr = try resolveHostPort(peer_str);
-        _ = try std.Thread.spawn(.{}, connectToPeer, .{peer_addr});
+    // ── 既知ピアへ同時接続 ─────────────────
+    for (known_peers) |spec| {
+        const peer_addr = try resolveHostPort(spec);
+        _ = try std.Thread.spawn(.{}, dialLoop, .{peer_addr});
     }
 
-    runMiningConsoleLoop();
+    // main スレッドを維持
+    while (true) std.time.sleep(60 * std.time.ns_per_s); // ★ 0.14 は ns_per_s を使う  [oai_citation_attribution:1‡Welcome | zig.guide](https://zig.guide/standard-library/threads/)
 }
 
-/// Accept incoming connections and spawn peer handlers.
-/// TODO: replace stub with real implementation.
-fn listenLoop(listener: *std.net.Server) !void {
-    defer listener.deinit();
-    while (true) {
-        const conn = try listener.accept();
-        // For now, just close the socket to prove compilation.
-        conn.stream.close();
-    }
-}
-
-/// Dial to a remote peer and start the peer loop.
-/// TODO: implement real peer communication.
-fn connectToPeer(addr: std.net.Address) !void {
-    var sock = try std.net.tcpConnectToAddress(addr);
-    defer sock.close();
-    // Placeholder: immediately return after connecting.
-}
-
-/// Parse "host:port" into std.net.Address.
-/// Very small helper for early compilation.
+// ---------- util ----------
 fn resolveHostPort(spec: []const u8) !std.net.Address {
     var it = std.mem.tokenizeScalar(u8, spec, ':');
-    const host = it.next() orelse return error.InvalidFormat;
-    const port_str = it.next() orelse return error.InvalidFormat;
-    const port = try std.fmt.parseInt(u16, port_str, 10);
+    const host = it.next() orelse return error.Invalid;
+    const port_s = it.next() orelse return error.Invalid;
+    const port = try std.fmt.parseInt(u16, port_s, 10);
     return std.net.Address.resolveIp(host, port);
 }
 
-/// Placeholder for the interactive mining loop.
-/// TODO: implement actual user‑input mining logic.
-fn runMiningConsoleLoop() void {
-    // At this stage we only need a no‑op to satisfy the linker.
-    // Insert real code later.
+// ---------- accept ----------
+fn acceptLoop(listener: *std.net.Server) !void {
+    defer listener.deinit();
+    while (true) {
+        const conn = try listener.accept();
+        const peer = types.Peer{ .address = conn.address, .stream = conn.stream };
+        try blockchain.peer_list.append(peer);
+        _ = try std.Thread.spawn(.{}, peerLoop, .{peer});
+    }
+}
+
+// ---------- dial (再接続付き) ----------
+fn dialLoop(addr: std.net.Address) !void {
+    while (true) {
+        if (std.net.tcpConnectToAddress(addr)) |sock| { //  [oai_citation_attribution:2‡GitHub](https://github.com/cedrickchee/experiments/blob/master/zig/zig-by-example/tcp-connection.zig?utm_source=chatgpt.com)
+            std.log.info("connected {any}", .{addr});
+            const peer = types.Peer{ .address = addr, .stream = sock };
+            try blockchain.peer_list.append(peer);
+            try peer.stream.writer().writeAll("GET_CHAIN\n");
+            peerLoop(peer) catch |e| std.log.err("{any}", .{e});
+        } else |err| std.log.warn("dial fail: {any}", .{err});
+        std.time.sleep(5 * std.time.ns_per_s);
+    }
+}
+
+// ---------- peer I/O ----------
+fn peerLoop(peer: types.Peer) !void {
+    defer {
+        removePeer(peer);
+        peer.stream.close();
+    }
+
+    var reader = peer.stream.reader();
+    var buf: [1024]u8 = undefined;
+
+    while (true) {
+        const n = try reader.read(&buf);
+        if (n == 0) break;
+
+        const msg = buf[0..n];
+
+        if (std.mem.startsWith(u8, msg, "BLOCK:")) {
+            const blk = try parser.parseBlockJson(msg[6..]);
+            blockchain.addBlock(blk);
+            broadcastBlock(blk, peer);
+        } else if (std.mem.startsWith(u8, msg, "GET_CHAIN")) {
+            try sendChain(peer);
+        }
+    }
+}
+
+// ── broadcast ----------
+fn broadcastBlock(blk: types.Block, from: types.Peer) void {
+    const payload = parser.serializeBlock(blk) catch return;
+    for (blockchain.peer_list.items) |p| {
+        // ★ getPort() で比較
+        if (p.address.getPort() == from.address.getPort()) continue;
+        var w = p.stream.writer();
+        _ = w.writeAll("BLOCK:") catch {}; // ★ 別 write
+        _ = w.writeAll(payload) catch {};
+    }
+}
+
+// ── chain sync ----------
+fn sendChain(peer: types.Peer) !void {
+    var w = peer.stream.writer();
+    for (blockchain.chain_store.items) |b| {
+        const j = try parser.serializeBlock(b);
+        try w.writeAll("BLOCK:"); // ★
+        try w.writeAll(j); // ★
+    }
+}
+
+// ── remove ----------
+fn removePeer(target: types.Peer) void {
+    var i: usize = 0;
+    while (i < blockchain.peer_list.items.len) : (i += 1) {
+        if (blockchain.peer_list.items[i].address.getPort() == target.address.getPort()) {
+            _ = blockchain.peer_list.orderedRemove(i);
+            break;
+        }
+    }
 }


### PR DESCRIPTION
This pull request introduces significant changes to the blockchain implementation in `references/chapter8/src/blockchain.zig` and `references/chapter8/src/main.zig`. The changes focus on enabling peer-to-peer communication, improving modularity, and enhancing the functionality of the blockchain network. Key updates include making `chain_store` and `peer_list` public, replacing placeholder functions with real implementations for peer handling, and adding new functionality for broadcasting blocks and synchronizing the blockchain.

### Peer-to-Peer Communication Enhancements:
* Made `chain_store` and `peer_list` public in `blockchain.zig`, allowing external access to these core data structures.
* Replaced the placeholder `connectToPeer` and `listenLoop` functions with fully implemented `dialLoop` and `acceptLoop` functions, enabling real peer connection and communication.
* Added a `peerLoop` function to handle peer I/O, including receiving and processing messages like `BLOCK:` and `GET_CHAIN`.

### Blockchain Synchronization and Broadcasting:
* Implemented `broadcastBlock` to propagate newly mined or received blocks to all connected peers except the sender.
* Added `sendChain` to synchronize the blockchain with peers by sending the entire chain when requested.

### Utility Improvements:
* Introduced the `removePeer` function to clean up disconnected peers from the `peer_list`.
* Refactored and renamed various functions for better clarity and modularity, such as `resolveHostPort` and `runMiningConsoleLoop`.