### PR TITLE
fix fail to connect in docker

### DIFF
--- a/references/chapter7/docker-compose.yml
+++ b/references/chapter7/docker-compose.yml
@@ -1,3 +1,12 @@
+# Docker Compose構成ファイル - ブロックチェーンノードネットワーク
+#
+# 使い方:
+# 1. 起動: docker compose up -d
+# 2. コンテナでコマンド実行: docker exec -it <container_name> <command>
+#    例: docker exec -it node2 sh -c "./zig-out/bin/block_client node1 3000 'Hello'"
+#
+# 注意: 新しいコンテナを起動するには docker compose run ではなく docker exec を使用してください
+
 services:
   node1:
     build: .
@@ -7,7 +16,9 @@ services:
       - "3001:3000"
     environment:
       - NODE_ID=1
-    command: sh -c "zig build && ./zig-out/bin/chapter7 --listen 3000"
+    command: sh -c "./zig-out/bin/chapter7 --listen 3000"
+    volumes:
+      - ./:/app
 
   node2:
     build: .
@@ -17,7 +28,9 @@ services:
       - "3002:3000"
     environment:
       - NODE_ID=2
-    command: sh -c "zig build && ./zig-out/bin/chapter7 --listen 3000 --connect node1:3000"
+    command: sh -c "./zig-out/bin/chapter7 --listen 3000 --connect node1:3000"
+    volumes:
+      - ./:/app
 
   node3:
     build: .
@@ -27,4 +40,6 @@ services:
       - "3003:3000"
     environment:
       - NODE_ID=3
-    command: sh -c "zig build && ./zig-out/bin/chapter7 --listen 3000 --connect node1:3000"
+    command: sh -c "./zig-out/bin/chapter7 --listen 3000 --connect node1:3000"
+    volumes:
+      - ./:/app


### PR DESCRIPTION
This pull request introduces enhancements to the Docker Compose configuration for a blockchain node network and updates the `main.zig` file to improve hostname resolution functionality. The most important changes include simplifying the Docker Compose commands, adding volume mounts for code sharing, and implementing DNS-based hostname resolution in the Zig application.

### Docker Compose improvements:
* Added a detailed comment block at the top of `docker-compose.yml` to explain usage instructions, including how to execute commands in containers and a note on using `docker exec` instead of `docker compose run`. (`references/chapter7/docker-compose.yml`, [references/chapter7/docker-compose.ymlR1-R9](diffhunk://#diff-14f5e52bedb286520ded725117ec55c5f75cfc930b7835f646dda0541749a1d5R1-R9))
* Simplified the `command` field for all nodes by removing the `zig build` step, assuming the build is done beforehand, and added volume mounts (`./:/app`) to share code between the host and containers. (`references/chapter7/docker-compose.yml`, [[1]](diffhunk://#diff-14f5e52bedb286520ded725117ec55c5f75cfc930b7835f646dda0541749a1d5L10-R21) [[2]](diffhunk://#diff-14f5e52bedb286520ded725117ec55c5f75cfc930b7835f646dda0541749a1d5L20-R33) [[3]](diffhunk://#diff-14f5e52bedb286520ded725117ec55c5f75cfc930b7835f646dda0541749a1d5L30-R45)

### Hostname resolution in Zig application:
* Imported `std.net` in `main.zig` to leverage networking utilities. (`references/chapter7/src/main.zig`, [references/chapter7/src/main.zigR5](diffhunk://#diff-32617c5979008ab4531f03cf1b008ec2a308d1e6a951ffda01d72ce6d5515cd8R5))
* Enhanced the `main` function to support both IP address and hostname resolution. Added logic to distinguish between IP addresses and hostnames, using DNS resolution for the latter. This ensures better flexibility and error handling when connecting to remote nodes. (`references/chapter7/src/main.zig`, [references/chapter7/src/main.zigL52-R72](diffhunk://#diff-32617c5979008ab4531f03cf1b008ec2a308d1e6a951ffda01d72ce6d5515cd8L52-R72))