### PR TITLE
update main listen port

### DIFF
--- a/references/chapter8/docker-compose.yml
+++ b/references/chapter8/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - "3001:3000"
     environment:
       - NODE_ID=1
-    command: sh -c "./zig-out/bin/chapter7 --listen 3000"
+    command: sh -c "./zig-out/bin/chapter8 --listen 3000"
 
   node2:
     <<: *common-config


### PR DESCRIPTION
This pull request introduces enhancements to the command-line interface and peer-to-peer connection handling in Chapter 8 of the project. The most significant updates include support for new command-line flags (`--listen` and `--connect`), improved argument parsing, and adjustments to the Docker Compose configuration to align with Chapter 8. These changes aim to improve usability and flexibility for running and connecting nodes.

### Command-Line Interface Enhancements:
* Updated the usage instructions to include new flags: `--listen` for specifying the port to listen on and `--connect` for defining known peer addresses. This provides a more explicit and flexible way to configure nodes. (`references/chapter8/src/main.zig`, [[1]](diffhunk://#diff-be430cb21a736d04ae3b0dff682eb5e15fa1bf6591e93ad442fd970099fdffcaR23-R30) [[2]](diffhunk://#diff-be430cb21a736d04ae3b0dff682eb5e15fa1bf6591e93ad442fd970099fdffcaL40-R82)
* Refactored argument parsing logic to handle the new flags. The program now validates the presence of required arguments and supports both the new and legacy argument formats. (`references/chapter8/src/main.zig`, [references/chapter8/src/main.zigL40-R82](diffhunk://#diff-be430cb21a736d04ae3b0dff682eb5e15fa1bf6591e93ad442fd970099fdffcaL40-R82))

### Peer-to-Peer Connection Handling:
* Adjusted the loop for connecting to known peers to use the updated argument parsing structure (`known_peers.items`). This ensures compatibility with the new argument handling. (`references/chapter8/src/main.zig`, [references/chapter8/src/main.zigL56-R91](diffhunk://#diff-be430cb21a736d04ae3b0dff682eb5e15fa1bf6591e93ad442fd970099fdffcaL56-R91))

### Docker Compose Configuration:
* Updated the `command` in the Docker Compose file to use the Chapter 8 binary (`chapter8`) instead of the Chapter 7 binary (`chapter7`). This aligns the configuration with the current chapter's implementation. (`references/chapter8/docker-compose.yml`, [references/chapter8/docker-compose.ymlL25-R25](diffhunk://#diff-d7693f7ed1169c7db5e4459ab07fc5aa9de03edbc3330274d5ec99a5d7848bc3L25-R25))