### PR TITLE
refactor ci add permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,19 +1,22 @@
 name: Zig CI
 
+permissions:
+  contents: read
+
 on:
   push: {}
+  pull_request: {}
 
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Setup Zig
-      uses: goto-bus-stop/setup-zig@v2
-      with:
-        version: 0.14.0
+      - name: Setup Zig
+        uses: goto-bus-stop/setup-zig@v2
+        with:
+          version: 0.14.0
 
-    - name: Run tests
-      run: zig build test
+      - name: Run tests
+        run: zig build test


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to enhance security and trigger builds on pull requests.

Changes to `.github/workflows/ci.yml`:

* Added `permissions` to restrict access to read-only for contents, improving security.
* Updated the workflow to trigger on `pull_request` events in addition to `push` events.