### PR TITLE
fix host name resolution

### DIFF
--- a/references/chapter8/docker-compose.yml
+++ b/references/chapter8/docker-compose.yml
@@ -3,7 +3,7 @@
 # 使い方:
 # 1. 起動: docker compose up -d
 # 2. コンテナでコマンド実行: docker exec -it <container_name> <command>
-#    例: docker exec -it node2 sh -c "./zig-out/bin/block_client node1 3000 'Hello'"
+#    例: docker compose exec -it node2 sh -c "./zig-out/bin/chapter8 --listen 3000 --connect node1:3000"
 #
 # 注意: 新しいコンテナを起動するには docker compose run ではなく docker exec を使用してください
 
@@ -22,7 +22,7 @@ services:
       - "3001:3000"
     environment:
       - NODE_ID=1
-    command: sh -c "./zig-out/bin/chapter8 --listen 3000"
+    command: ./zig-out/bin/chapter8 --listen 3000
 
   node2:
     <<: *common-config


### PR DESCRIPTION
This pull request includes updates to the `docker-compose.yml` file and improvements to the `resolveHostPort` function in the Zig source code. The changes enhance usability for running and debugging the project, and improve hostname resolution logic to handle special cases and errors more robustly.

### Updates to `docker-compose.yml`:

* **Improved example command for clarity**: Updated the example in the comments to use `docker compose exec` with the new command syntax for running Chapter 8's application (`references/chapter8/docker-compose.yml`, [references/chapter8/docker-compose.ymlL6-R6](diffhunk://#diff-d7693f7ed1169c7db5e4459ab07fc5aa9de03edbc3330274d5ec99a5d7848bc3L6-R6)).
* **Simplified command execution**: Removed the unnecessary `sh -c` wrapper from the `command` directive for `node1` to streamline execution (`references/chapter8/docker-compose.yml`, [references/chapter8/docker-compose.ymlL25-R25](diffhunk://#diff-d7693f7ed1169c7db5e4459ab07fc5aa9de03edbc3330274d5ec99a5d7848bc3L25-R25)).

### Enhancements to hostname resolution:

* **Special case for `localhost`**: Modified the `resolveHostPort` function to directly map `localhost` to `127.0.0.1`, bypassing unnecessary hostname resolution steps (`references/chapter8/src/p2p.zig`, [references/chapter8/src/p2p.zigL250-R272](diffhunk://#diff-2f2a37ca2f33b75d65f377b43bf2bebed51172cfd452586d173759062b923796L250-R272)).
* **Improved error handling**: Added logic to handle invalid IP formats and attempt hostname resolution, returning an appropriate error if no address is found or the hostname is unknown (`references/chapter8/src/p2p.zig`, [references/chapter8/src/p2p.zigL250-R272](diffhunk://#diff-2f2a37ca2f33b75d65f377b43bf2bebed51172cfd452586d173759062b923796L250-R272)).