### PR TITLE
add contract and solc command usage

### DIFF
--- a/references/chapter9/contract/SimpleAdder.sol
+++ b/references/chapter9/contract/SimpleAdder.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract Adder {
+    function add(uint256 a, uint256 b) public pure returns (uint256) {
+        return a + b;
+    }
+}


### PR DESCRIPTION
This pull request introduces a new Solidity contract, `Adder`, in the `SimpleAdder.sol` file. The contract provides a single function to add two unsigned integers.

Key changes:

* [`references/chapter9/contract/SimpleAdder.sol`](diffhunk://#diff-25588c680a6acea80d115f6e860c52b5118847d9966db15bbe871bd71fc44c16R1-R8): Added the `Adder` contract, which includes a `add` function that takes two `uint256` parameters and returns their sum. The contract uses the MIT license and Solidity version `^0.8.0`.