### PR TITLE
add solidity contract

### DIFF
--- a/contract/SimpleAdder.sol
+++ b/contract/SimpleAdder.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+contract Adder {
+    function add(uint256 a, uint256 b) public pure returns (uint256) {
+        return a + b;
+    }
+}


### PR DESCRIPTION
This pull request introduces a new smart contract `Adder` in the `contract/SimpleAdder.sol` file. The contract includes a single function to perform addition.

New functionality:

* [`contract/SimpleAdder.sol`](diffhunk://#diff-7e6747110101438e9030220c402f1d2af48cb7469789e2bf78542bc18e021060R1-R8): Added a new Solidity contract named `Adder` with a function `add` that takes two unsigned integers as input and returns their sum. The contract uses Solidity version `^0.8.30` and is licensed under MIT.