### PR TITLE
Fix/evm tx broadcast json

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -305,7 +305,7 @@ fn deployContract(allocator: std.mem.Allocator, bytecode_hex: []const u8, contra
     };
 
     // P2Pネットワーク上でトランザクションをブロードキャスト
-    try p2p.broadcastEvmTransaction(allocator, tx);
+    try p2p.broadcastEvmTransaction(tx);
     std.log.info("デプロイトランザクションをブロードキャストしました", .{});
 
     // ローカルでもトランザクションを処理して即時デプロイする
@@ -358,7 +358,7 @@ fn callContract(allocator: std.mem.Allocator, contract_address: []const u8, inpu
     };
 
     // P2Pネットワーク上でトランザクションをブロードキャスト
-    try p2p.broadcastEvmTransaction(allocator, tx);
+    try p2p.broadcastEvmTransaction(tx);
 
     std.log.info("呼び出しトランザクションをブロードキャストしました", .{});
 

--- a/src/p2p.zig
+++ b/src/p2p.zig
@@ -635,12 +635,11 @@ test "EVM transaction queuing and flushing" {
     }
     try std.testing.expectEqual(@as(usize, 0), pending_evm_txs.items.len);
 
-
     // Create a sample transaction
     const sample_evm_data_bytes = try allocator.dupe(u8, "test_evm_data"); // Raw bytes
     // defer allocator.free(sample_evm_data_bytes); // Will be owned by tx1
 
-    var tx1 = types.Transaction{
+    const tx1 = types.Transaction{
         .sender = try allocator.dupe(u8, "sender1_addr"),
         .receiver = try allocator.dupe(u8, "receiver1_addr"),
         .amount = 100,
@@ -686,7 +685,6 @@ test "EVM transaction queuing and flushing" {
     };
     try peer_list.append(mock_peer);
 
-
     // Manually call the flushing logic (as in listenLoop/connectToPeer)
     std.log.info("Test: Flushing {d} pending EVM transactions to new mock peer", .{pending_evm_txs.items.len});
     for (pending_evm_txs.items) |payload_to_flush| {
@@ -700,7 +698,6 @@ test "EVM transaction queuing and flushing" {
         allocator.free(pending_evm_txs.pop());
     }
     pending_evm_txs.clearRetainingCapacity(); // Match the main code's behavior
-
 
     // Assertions after flushing:
     // 1. Assert that pending_evm_txs is now empty
@@ -725,7 +722,7 @@ test "EVM transaction JSON format consistency (serialize/parse)" {
     const original_evm_data_bytes = try allocator.dupe(u8, "raw_evm_data_payload");
     // defer allocator.free(original_evm_data_bytes); // Owned by tx2
 
-    var tx2 = types.Transaction{
+    const tx2 = types.Transaction{
         .sender = try allocator.dupe(u8, "sender_addr_tx2"),
         .receiver = try allocator.dupe(u8, "receiver_addr_tx2"),
         .amount = 12345,
@@ -739,18 +736,16 @@ test "EVM transaction JSON format consistency (serialize/parse)" {
     defer allocator.free(tx2.receiver);
     if (tx2.evm_data) |d| allocator.free(d);
 
-
     // 2. Serialize tx2
     const payload = try parser.serializeTransaction(allocator, tx2);
     defer allocator.free(payload);
 
     // 3. Parse the payload
-    var parsed_tx = try parser.parseTransactionJson(payload);
+    const parsed_tx = try parser.parseTransactionJson(payload);
     // Defer freeing fields of parsed_tx
     defer allocator.free(parsed_tx.sender);
     defer allocator.free(parsed_tx.receiver);
     if (parsed_tx.evm_data) |d| allocator.free(d);
-
 
     // 4. Assertions
     // Using expectEqualStrings for direct comparison. Assumes null termination or exact length match.


### PR DESCRIPTION
This pull request introduces significant changes to the handling of Ethereum Virtual Machine (EVM) transactions in the codebase, focusing on improving transaction broadcasting, queuing, and serialization. The most important changes include simplifying the `broadcastEvmTransaction` function, adding queuing and flushing mechanisms for pending EVM transactions, and introducing new serialization and parsing utilities for transactions.

### EVM Transaction Handling Improvements:
* **Simplified `broadcastEvmTransaction` Function**: Removed the inline JSON construction logic and replaced it with a call to the new `serializeTransaction` function. Transactions are now queued if no peers are available or if broadcasting fails.
* **Added Queuing and Flushing for Pending Transactions**: Introduced `pending_evm_txs` to store transactions that could not be broadcast immediately. Transactions are flushed to new peers during connection or when a peer joins. [[1]](diffhunk://#diff-e080a1fec38da75c3c0070300de8f2b486c32df501409d9af8edf804f1ddc142R22) [[2]](diffhunk://#diff-e080a1fec38da75c3c0070300de8f2b486c32df501409d9af8edf804f1ddc142R58-R69) [[3]](diffhunk://#diff-e080a1fec38da75c3c0070300de8f2b486c32df501409d9af8edf804f1ddc142R109-R120)

### Serialization and Parsing Enhancements:
* **New `serializeTransaction` Function**: Added a utility to serialize transaction structures into JSON strings for network transmission, including support for EVM-specific fields.
* **Improved Parsing Logic**: Adjusted transaction parsing to ensure compatibility with the updated serialization format.

### Testing and Mocking:
* **Comprehensive Tests for EVM Transactions**: Added tests to verify transaction queuing, flushing, and serialization consistency. Mock stream writers were introduced to simulate peer communication in tests.

### Minor Adjustments:
* **Removed Unused Allocator Parameter**: Simplified the `broadcastEvmTransaction` function by removing the unused `allocator` parameter. [[1]](diffhunk://#diff-d924ca21d81d7d5a59eb9e10d3e2689c4c58a7e28e6ecce6a064701666f5a730L308-R308) [[2]](diffhunk://#diff-d924ca21d81d7d5a59eb9e10d3e2689c4c58a7e28e6ecce6a064701666f5a730L361-R361)
* **Documentation Cleanup**: Removed redundant comments and updated function documentation to reflect the new behavior. [[1]](diffhunk://#diff-d74dadc57efeb3cad49ee4c0fde55a998975a9a83ca52698ca53b1d51eb46220L1-L7) [[2]](diffhunk://#diff-d74dadc57efeb3cad49ee4c0fde55a998975a9a83ca52698ca53b1d51eb46220L548-R553)