### PR TITLE
修正(p2p.zig): エラー処理の改善: EVMトランザクション解析時のエラー処理を改善

### DIFF
--- a/src/p2p.zig
+++ b/src/p2p.zig
@@ -474,7 +474,7 @@ fn handleMessage(msg: []const u8, from_peer: types.Peer) !void {
 
         // EVMトランザクションメッセージを処理
         std.log.info("解析開始: parseTransactionJson (行:{d})", .{@src().line + 1});
-        var evm_tx = parser.parseTransactionJson(msg[8..]) catch |err| {
+        var evm_tx = parser.parseTransactionJson(payload) catch |err| {
             std.log.err("Error parsing EVM transaction from {any}: {any} (at 行:{d})", .{ from_peer.address, err, @src().line });
             return;
         };


### PR DESCRIPTION
This pull request makes a small but important change in the `handleMessage` function within the `src/p2p.zig` file. The change involves replacing the `msg[8..]` slice with the `payload` variable when parsing an EVM transaction.

Key change:

* Updated the call to `parser.parseTransactionJson` to use `payload` instead of slicing `msg` (`msg[8..]`) for better clarity and potential correctness in handling the input data.