### PR TITLE
修正(utils.zig): joinStringsのメモリコピーを@memcpyに置き換え

### DIFF
--- a/src/blockchain.zig
+++ b/src/blockchain.zig
@@ -355,7 +355,9 @@ pub fn syncChain(blocks: []types.Block) !void {
                     try addresses.append(address);
                 }
 
-                std.log.info("Block {d} contains contracts at addresses: {s}", .{ block.index, try utils.joinStrings(std.heap.page_allocator, addresses.items, ", ") });
+                const addresses_str = utils.joinStrings(std.heap.page_allocator, addresses.items, ", ") catch "";
+                defer std.heap.page_allocator.free(addresses_str);
+                std.log.info("Block {d} contains contracts at addresses: {s}", .{ block.index, addresses_str });
 
                 // 改めてイテレータを初期化して処理
                 it = contracts.iterator();

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -221,12 +221,12 @@ pub fn joinStrings(allocator: std.mem.Allocator, slices: []const []const u8, sep
     // バッファに文字列を連結
     var pos: usize = 0;
     for (slices, 0..slices.len) |slice, i| {
-        std.mem.copy(u8, result[pos..], slice);
+        @memcpy(result[pos .. pos + slice.len], slice);
         pos += slice.len;
 
         // セパレータを追加（最後の要素以外）
         if (i < slices.len - 1) {
-            std.mem.copy(u8, result[pos..], separator);
+            @memcpy(result[pos .. pos + separator.len], separator);
             pos += separator.len;
         }
     }


### PR DESCRIPTION
This pull request improves memory safety and error handling in the blockchain codebase, while also optimizing string operations. Key changes include adding proper resource cleanup, improving error handling during string duplication and storage, and replacing `std.mem.copy` with the more efficient `@memcpy` for string concatenation.

### Memory Safety and Error Handling Improvements:

* In `src/blockchain.zig`, added error handling for string concatenation in `syncChain` by using `catch` to handle potential allocation failures and ensuring memory is freed with `defer`.
* In `src/parser.zig`, added `errdefer` to ensure proper cleanup of the `contracts` hashmap, and improved error handling for string duplication and storage in `parseBlockFromJsonObj`. This includes freeing memory for addresses and contract bytecode in case of errors.

### String Operation Optimization:

* In `src/utils.zig`, replaced `std.mem.copy` with `@memcpy` in `joinStrings` to improve performance when concatenating strings and separators.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling and memory management during contract parsing, ensuring resources are properly cleaned up on errors.
	- Enhanced logging reliability during blockchain synchronization to prevent potential errors from affecting log output.

- **Refactor**
	- Updated internal methods for copying memory to use more efficient built-in functions, with no impact on visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->