### PR TITLE
修正(evm_debug.zig): 比較・論理命令の説明を追加

### DIFF
--- a/src/evm_debug.zig
+++ b/src/evm_debug.zig
@@ -37,7 +37,16 @@ pub fn disassembleContext(context: *EvmContext, writer: anytype) !void {
             Opcode.JUMPI => try writer.print("JUMPI", .{}),
             Opcode.JUMPDEST => try writer.print("JUMPDEST", .{}),
             Opcode.RETURN => try writer.print("RETURN", .{}),
+            Opcode.REVERT => try writer.print("REVERT", .{}),
 
+            // Comparison and logic operations
+            Opcode.LT => try writer.print("LT", .{}),
+            Opcode.GT => try writer.print("GT", .{}),
+            Opcode.SLT => try writer.print("SLT", .{}),
+            Opcode.EQ => try writer.print("EQ", .{}),
+            Opcode.ISZERO => try writer.print("ISZERO", .{}),
+
+            Opcode.POP => try writer.print("POP", .{}),
             Opcode.PUSH0 => try writer.print("PUSH0", .{}),
             Opcode.PUSH1 => {
                 if (pc + 1 < context.code.len) {
@@ -111,6 +120,12 @@ pub fn getOpcodeDescription(opcode: u8) []const u8 {
         Opcode.JUMPI => "条件付きジャンプ",
         Opcode.JUMPDEST => "ジャンプ先としての目印",
         Opcode.RETURN => "実行を停止し、メモリからのデータを返す",
+        Opcode.REVERT => "実行を停止し、状態変更を巻き戻し、メモリからのデータを返す",
+        Opcode.LT => "符号なし未満比較（b < a の場合1、そうでなければ0）",
+        Opcode.GT => "符号なし超過比較（b > a の場合1、そうでなければ0）",
+        Opcode.SLT => "符号付き未満比較（b < a の場合1、そうでなければ0）",
+        Opcode.EQ => "等価比較（a == b の場合1、そうでなければ0）",
+        Opcode.ISZERO => "ゼロ判定（a == 0 の場合1、そうでなければ0）",
         Opcode.PUSH0 => "スタックに0をプッシュ",
         Opcode.PUSH1 => "スタックに1バイトの値をプッシュ",
         Opcode.PUSH2 => "スタックに2バイトの値をプッシュ",
@@ -395,6 +410,7 @@ pub fn disassembleBytecode(code: []const u8, start_pc: ?usize, max_instructions:
             0x0a => try writer.print("EXP        |", .{}),
             0x10 => try writer.print("LT         |", .{}),
             0x11 => try writer.print("GT         |", .{}),
+            0x12 => try writer.print("SLT        |", .{}),
             0x14 => try writer.print("EQ         |", .{}),
             0x15 => try writer.print("ISZERO     |", .{}),
             0x16 => try writer.print("AND        |", .{}),


### PR DESCRIPTION
This pull request introduces new EVM opcode implementations, enhances the disassembler with support for additional opcodes, and improves the formatting of disassembled bytecode. Below are the most important changes grouped by theme:

### New Opcode Implementations:
* Added support for the `GT` (greater than) opcode, which compares two stack values and pushes `1` if `b > a`, otherwise `0`.
* Added support for the `SLT` (signed less than) opcode, which performs a signed comparison of two stack values and pushes `1` if `b < a`, otherwise `0`.

### Opcode Additions:
* Introduced the `INVALID` opcode in the `Opcode` struct. This serves as a placeholder for undefined or invalid opcodes.

### Disassembler Enhancements:
* Updated the `disassemble` function to include new opcodes (`REVERT`, `INVALID`, `LT`, `GT`, `SLT`, `EQ`, and `ISZERO`) for better debugging and analysis.
* Improved the formatting of `PUSH` instructions in the disassembler by adding a `0x` prefix to the pushed bytes for clarity.

### Debugging Improvements:
* Enhanced the `disassembleContext` function to support new opcodes (`REVERT`, `LT`, `GT`, `SLT`, `EQ`, and `ISZERO`) for more comprehensive debugging output.
* Updated opcode descriptions in `getOpcodeDescription` to include detailed explanations for the new opcodes (`REVERT`, `LT`, `GT`, `SLT`, `EQ`, and `ISZERO`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the GT (greater than) and SLT (signed less than) comparison opcodes in EVM execution.
  - Enhanced disassembly output to recognize and display additional opcodes, including REVERT, INVALID, LT, GT, SLT, EQ, ISZERO, and POP, along with their descriptions.
  - Improved formatting for PUSH instruction output in disassembly for clearer hex string representation.

- **Bug Fixes**
  - Corrected stack value order when handling the JUMPI opcode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->