### PR TITLE
修正(evm.zig): 0除算のエラー処理を追加

### DIFF
--- a/src/evm.zig
+++ b/src/evm.zig
@@ -325,6 +325,26 @@ fn executeStep(context: *EvmContext) !void {
             context.pc += 1;
         },
 
+        Opcode.MOD => {
+            if (context.stack.depth() < 2) return EVMError.StackUnderflow;
+            const a = try context.stack.pop();
+            const b = try context.stack.pop();
+            // 0除算の場合は0を返す
+            if (b.hi == 0 and b.lo == 0) {
+                try context.stack.push(EVMu256.zero());
+            } else {
+                // 簡易版ではu64の範囲のみサポート
+                if (a.hi == 0 and b.hi == 0) {
+                    const result = EVMu256.fromU64(@intCast(a.lo % b.lo));
+                    try context.stack.push(result);
+                } else {
+                    // 本来はより複雑な処理が必要
+                    try context.stack.push(EVMu256.zero());
+                }
+            }
+            context.pc += 1;
+        },
+
         // PUSH1: 1バイトをスタックにプッシュ
         Opcode.PUSH1 => {
             if (context.pc + 1 >= context.code.len) return EVMError.InvalidOpcode;


### PR DESCRIPTION
This pull request adds support for the `MOD` opcode in the `executeStep` function of the Ethereum Virtual Machine (EVM) implementation. The change includes handling for stack underflows, zero division, and basic modulo operations within the `u64` range.

### Added support for the `MOD` opcode:
* Implemented the `MOD` opcode in the `executeStep` function to perform modulo operations. This includes:
  - Checking for stack underflow and returning `EVMError.StackUnderflow` if the stack has fewer than two elements.
  - Handling division by zero by pushing `EVMu256.zero()` to the stack.
  - Supporting modulo operations for values within the `u64` range and pushing the result to the stack.
  - Defaulting to pushing `EVMu256.zero()` for values outside the `u64` range, with a note that more complex handling is required for full support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the MOD (modulo) operation in the EVM, allowing calculation of the remainder for 64-bit values.
- **Bug Fixes**
  - Handles division by zero in the MOD operation by pushing zero onto the stack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->