### PR TITLE
add mod and call data copy

### DIFF
--- a/src/evm.zig
+++ b/src/evm.zig
@@ -436,9 +436,9 @@ fn executeStep(context: *EvmContext) !void {
                 std.log.info("CALLDATALOAD: Loading function selector from calldata", .{});
                 if (context.calldata.len >= 4) {
                     const selector = (@as(u32, context.calldata[0]) << 24) |
-                                   (@as(u32, context.calldata[1]) << 16) |
-                                   (@as(u32, context.calldata[2]) << 8) |
-                                   @as(u32, context.calldata[3]);
+                        (@as(u32, context.calldata[1]) << 16) |
+                        (@as(u32, context.calldata[2]) << 8) |
+                        @as(u32, context.calldata[3]);
                     std.log.info("CALLDATALOAD: First 4 bytes (function selector): 0x{x:0>8}", .{selector});
                 }
                 std.log.info("CALLDATALOAD: Full calldata: {any}", .{context.calldata});
@@ -675,7 +675,7 @@ fn executeStep(context: *EvmContext) !void {
                 if (shift.lo == 224) {
                     std.log.info("SHR: Result after 224-bit shift - hi: 0x{x:0>32}, lo: 0x{x:0>32}", .{ result.hi, result.lo });
                     if (result.lo <= 0xFFFFFFFF) {
-                        std.log.info("SHR: Extracted function selector: 0x{x:0>8}", .{ @as(u32, @intCast(result.lo)) });
+                        std.log.info("SHR: Extracted function selector: 0x{x:0>8}", .{@as(u32, @intCast(result.lo))});
                     }
                 }
 
@@ -1115,6 +1115,10 @@ pub fn disassemble(code: []const u8, writer: anytype) !void {
             Opcode.SLT => try writer.print("SLT", .{}),
             Opcode.EQ => try writer.print("EQ", .{}),
             Opcode.ISZERO => try writer.print("ISZERO", .{}),
+
+            // Missing opcodes that were showing as UNKNOWN
+            Opcode.MOD => try writer.print("MOD", .{}),
+            Opcode.CALLDATACOPY => try writer.print("CALLDATACOPY", .{}),
 
             Opcode.PUSH0 => try writer.print("PUSH0", .{}),
             Opcode.PUSH1 => {


### PR DESCRIPTION
This pull request addresses missing opcode handling in the `disassemble` function within the `src/evm.zig` file. The changes ensure that specific opcodes previously marked as `UNKNOWN` are now correctly recognized and printed.

Opcode handling improvements:

* [`src/evm.zig`](diffhunk://#diff-cc62562b105cf63a25e22946fd84ddd107e2e553f9f154ad57e7ab646d6fa0f3R1119-R1122): Added support for the `MOD` and `CALLDATACOPY` opcodes in the `disassemble` function to prevent them from being incorrectly identified as `UNKNOWN`.