### PR TITLE
Adderに四則演算(sub/mul/div)を追加し、READMEに呼び出し例を追記

### DIFF
--- a/references/chapter9/contract/SimpleAdder.sol
+++ b/references/chapter9/contract/SimpleAdder.sol
@@ -5,4 +5,18 @@ contract Adder {
     function add(uint256 a, uint256 b) public pure returns (uint256) {
         return a + b;
     }
+
+    function sub(uint256 a, uint256 b) public pure returns (uint256) {
+        require(b <= a, "underflow");
+        return a - b;
+    }
+
+    function mul(uint256 a, uint256 b) public pure returns (uint256) {
+        return a * b;
+    }
+
+    function div(uint256 a, uint256 b) public pure returns (uint256) {
+        require(b != 0, "division by zero");
+        return a / b;
+    }
 }


### PR DESCRIPTION
タイトル: Adderに四則演算(sub/mul/div)を追加し、READMEに呼び出し例を追記

概要:
- 既存のAdderコントラクトに減算・乗算・除算を追加し、安全性のためのrequireを付与しました。
- READMEにsolcでのセレクタ取得〜DATA生成〜zigによる実行例を追記し、動作確認手順を明確化しました。

変更内容:
- references/chapter9/contract/SimpleAdder.sol
  - sub(uint256 a, uint256 b): b <= a をrequireで検証し、アンダーフローを防止。
  - mul(uint256 a, uint256 b)
  - div(uint256 a, uint256 b): b != 0 をrequireで検証し、ゼロ除算を防止。
- README.md
  - Adder.sol の四則演算 呼び出し例（sub/mul/div）を追加。
  - トラブルシューティングの補足を追記。

目的:
- サンプル実装として四則演算を一通り提供し、EVMコールデータの生成〜実行の学習・検証を容易にするため。
- 入力検証（アンダーフロー／ゼロ除算）を明示し、意図しないREVERTやバグの混入を防ぐため。

動作確認:
以下はREADMEに追記した手順です（抜粋）。事前にsolcとzigの実行環境をご用意ください。

- sub(10,3)
```bash
SEL=$(solc --hashes references/chapter9/contract/SimpleAdder.sol | awk '/sub\(uint256,uint256\)/{print $1}' | sed 's/://')
A=$(printf "%064x" 10); B=$(printf "%064x" 3); DATA=0x${SEL}${A}${B}
zig build run -- --listen 9001 --connect 127.0.0.1:9000 --call 0x000000000000000000000000000000000000abcd "$DATA" --gas 100000 --sender 0x000000000000000000000000000000000000dead
# 期待: 結果=7
```

- mul(6,7)
```bash
SEL=$(solc --hashes references/chapter9/contract/SimpleAdder.sol | awk '/mul\(uint256,uint256\)/{print $1}' | sed 's/://')
A=$(printf "%064x" 6); B=$(printf "%064x" 7); DATA=0x${SEL}${A}${B}
zig build run -- --listen 9001 --connect 127.0.0.1:9000 --call 0x000000000000000000000000000000000000abcd "$DATA" --gas 100000 --sender 0x000000000000000000000000000000000000dead
# 期待: 結果=42
```

- div(100,4)
```bash
SEL=$(solc --hashes references/chapter9/contract/SimpleAdder.sol | awk '/div\(uint256,uint256\)/{print $1}' | sed 's/://')
A=$(printf "%064x" 100); B=$(printf "%064x" 4); DATA=0x${SEL}${A}${B}
zig build run -- --listen 9001 --connect 127.0.0.1:9000 --call 0x000000000000000000000000000000000000abcd "$DATA" --gas 100000 --sender 0x000000000000000000000000000000000000dead
# 期待: 結果=25
```

注意点:
- sub は b <= a、div は b != 0 を満たさないと REVERT します。
- hexToBytes の InvalidCharacter はDATAが空の可能性があるため、echo "$DATA" で確認してください。

影響範囲:
- ABIに3関数（sub/mul/div）が追加されます。既存のaddは非変更。
- 既存のコントラクトアドレスやストレージ互換性への影響はありません（pure関数のみ）。

互換性/破壊的変更:
- 破壊的変更なし。

セキュリティ:
- アンダーフロー防止とゼロ除算防止をrequireで実装済み。
- 追加関数はpureであり、状態変更や権限管理は不要。

パフォーマンス/ガス:
- 基本的な算術演算のみで追加オーバーヘッドは最小。
- requireの失敗時はREVERTコストが発生。

テスト:
- README記載の手順で手動テスト可能。
- 必要に応じてFoundry/Hardhat等での単体テスト追加は別PRで対応可能。

関連:
- コミット: add other caluculate（タイポは原文のまま）

チェックリスト:
- [x] コードの自己レビュー
- [x] READMEの更新
- [x] 入力検証（underflow/zero-division）
- [ ] 追加の自動テスト（任意）

ラベル提案:
- enhancement
- docs