### PR TITLE
🐛 修正(p2p): テストをzig 0.14対応（DI化・pop/UAF/アロケータ）＋mise pin

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,3 @@
+[tools]
+# CI (.github/workflows/ci.yml) が使う Zig バージョンに合わせる
+zig = "0.14.0"

--- a/src/p2p.zig
+++ b/src/p2p.zig
@@ -59,7 +59,7 @@ pub fn listenLoop(port: u16) !void {
         if (pending_evm_txs.items.len > 0) {
             std.log.info("Flushing {d} pending EVM transactions to new peer {any}", .{ pending_evm_txs.items.len, conn.address });
             for (pending_evm_txs.items) |payload| {
-                sendEvmTx(peer, payload) catch |err| {
+                sendEvmTx(peer.stream.writer(), peer.address, payload) catch |err| {
                     std.log.err("Failed to flush queued EVM transaction: {any}", .{err});
                     // エラーが発生しても次のペイロードへ
                 };
@@ -110,7 +110,7 @@ pub fn connectToPeer(addr: std.net.Address) !void {
         if (pending_evm_txs.items.len > 0) {
             std.log.info("Flushing {d} pending EVM transactions to new peer {any}", .{ pending_evm_txs.items.len, addr });
             for (pending_evm_txs.items) |payload| {
-                sendEvmTx(peer, payload) catch |err| {
+                sendEvmTx(peer.stream.writer(), peer.address, payload) catch |err| {
                     std.log.err("Failed to flush queued EVM transaction: {any}", .{err});
                     // エラーが発生しても次のペイロードへ
                 };
@@ -236,18 +236,17 @@ pub fn sendBlock(peer: types.Peer, blk: types.Block) !void {
 ///
 /// エラー:
 ///     ストリーム書き込みエラー
-fn sendEvmTx(peer: types.Peer, payload: []const u8) !void {
-    var writer = peer.stream.writer();
+fn sendEvmTx(writer: anytype, address: std.net.Address, payload: []const u8) !void {
     writer.writeAll("EVM_TX:") catch |err| {
-        std.log.err("Error sending EVM_TX to peer {any}: {any}", .{ peer.address, err });
+        std.log.err("Error sending EVM_TX to peer {any}: {any}", .{ address, err });
         return err;
     };
     writer.writeAll(payload) catch |err| {
-        std.log.err("Error sending EVM_TX payload to peer {any}: {any}", .{ peer.address, err });
+        std.log.err("Error sending EVM_TX payload to peer {any}: {any}", .{ address, err });
         return err;
     };
     writer.writeAll("\n") catch |err| {
-        std.log.err("Error sending newline after EVM_TX to peer {any}: {any}", .{ peer.address, err });
+        std.log.err("Error sending newline after EVM_TX to peer {any}: {any}", .{ address, err });
         return err;
     };
 }
@@ -275,7 +274,7 @@ pub fn broadcastEvmTransaction(tx: types.Transaction) !void {
 
     for (peer_list.items, 0..) |peer, idx| {
         std.log.info("ピア {d}/{d} にEVMトランザクションを送信 [行:{d}]: {}", .{ idx + 1, peer_count, @src().line, peer.address });
-        sendEvmTx(peer, payload) catch |err| {
+        sendEvmTx(peer.stream.writer(), peer.address, payload) catch |err| {
             std.log.err("Error broadcasting EVM_TX to peer {any}: {any} (at 行:{d})", .{ peer.address, err, @src().line });
             continue; // エラーが発生しても次のピアへ
         };
@@ -644,8 +643,10 @@ test "EVM transaction queuing and flushing" {
 
     // Ensure clean state before test by clearing and freeing any existing items
     peer_list.clearRetainingCapacity(); // Does not free items
-    while (pending_evm_txs.items.len > 0) {
-        allocator.free(pending_evm_txs.pop());
+    while (pending_evm_txs.pop()) |item| {
+        // Items are duped into the global queue with page_allocator by
+        // broadcastEvmTransaction, so they must be freed with the same allocator.
+        std.heap.page_allocator.free(item);
     }
     try std.testing.expectEqual(@as(usize, 0), pending_evm_txs.items.len);
 
@@ -664,7 +665,7 @@ test "EVM transaction queuing and flushing" {
     };
     defer allocator.free(tx1.sender);
     defer allocator.free(tx1.receiver);
-    if (tx1.evm_data) |d| allocator.free(d); // Free original evm_data
+    defer if (tx1.evm_data) |d| allocator.free(d); // Free original evm_data after all uses
 
     // 1. Call broadcastEvmTransaction with no peers
     try broadcastEvmTransaction(tx1);
@@ -684,32 +685,25 @@ test "EVM transaction queuing and flushing" {
     var mock_stream_data_buffer = std.ArrayList(u8).init(allocator);
     defer mock_stream_data_buffer.deinit();
 
-    // Create a mock writer
-    var mock_writer_instance = MockStreamWriter{ .buffer = &mock_stream_data_buffer };
+    // Create a mock writer. sendEvmTx takes the writer directly (dependency
+    // injection), so we can verify its output without a real socket.
+    const mock_writer_instance = MockStreamWriter{ .buffer = &mock_stream_data_buffer };
+    const dummy_address = try std.net.Address.parseIp("127.0.0.1", 8080);
 
-    // Create a mock stream source. Reader is not used by sendEvmTx.
-    const mock_stream_source = std.io.StreamSource{
-        .reader = undefined, // Not used by sendEvmTx
-        .writer = .{ .context = &mock_writer_instance, .writeFn = MockStreamWriter.write },
-    };
-
-    const mock_peer = types.Peer{
-        .address = try std.net.Address.parseIp("127.0.0.1", 8080), // Dummy address
-        .stream = mock_stream_source,
-    };
-    try peer_list.append(mock_peer);
-
-    // Manually call the flushing logic (as in listenLoop/connectToPeer)
-    std.log.info("Test: Flushing {d} pending EVM transactions to new mock peer", .{pending_evm_txs.items.len});
+    // Manually call the flushing logic (as in listenLoop/connectToPeer),
+    // writing to the mock writer instead of a real peer stream.
+    std.log.info("Test: Flushing {d} pending EVM transactions to mock writer", .{pending_evm_txs.items.len});
     for (pending_evm_txs.items) |payload_to_flush| {
-        try sendEvmTx(mock_peer, payload_to_flush);
+        try sendEvmTx(mock_writer_instance, dummy_address, payload_to_flush);
     }
 
     // The actual code uses pending_evm_txs.clearRetainingCapacity() which doesn't free items.
     // Items are freed because they are allocator.dupe'd into the queue.
     // So, here we must free them manually as they are popped.
-    while (pending_evm_txs.items.len > 0) {
-        allocator.free(pending_evm_txs.pop());
+    while (pending_evm_txs.pop()) |item| {
+        // Items are duped into the global queue with page_allocator by
+        // broadcastEvmTransaction, so they must be freed with the same allocator.
+        std.heap.page_allocator.free(item);
     }
     pending_evm_txs.clearRetainingCapacity(); // Match the main code's behavior
 
@@ -723,9 +717,6 @@ test "EVM transaction queuing and flushing" {
     try expected_sent_data_to_peer.writer().print("EVM_TX:{s}\n", .{expected_payload_tx1});
 
     try std.testing.expect(std.mem.eql(u8, expected_sent_data_to_peer.items, mock_stream_data_buffer.items));
-
-    // Clean up peer_list
-    _ = peer_list.pop(); // Remove mock_peer
 }
 
 test "EVM transaction JSON format consistency (serialize/parse)" {
@@ -748,7 +739,7 @@ test "EVM transaction JSON format consistency (serialize/parse)" {
     // Defer freeing fields of tx2
     defer allocator.free(tx2.sender);
     defer allocator.free(tx2.receiver);
-    if (tx2.evm_data) |d| allocator.free(d);
+    defer if (tx2.evm_data) |d| allocator.free(d);
 
     // 2. Serialize tx2
     const payload = try parser.serializeTransaction(allocator, tx2);
@@ -757,9 +748,11 @@ test "EVM transaction JSON format consistency (serialize/parse)" {
     // 3. Parse the payload
     const parsed_tx = try parser.parseTransactionJson(payload);
     // Defer freeing fields of parsed_tx
-    defer allocator.free(parsed_tx.sender);
-    defer allocator.free(parsed_tx.receiver);
-    if (parsed_tx.evm_data) |d| allocator.free(d);
+    // parseTransactionJson allocates these fields with page_allocator internally,
+    // so they must be freed with the same allocator.
+    defer std.heap.page_allocator.free(parsed_tx.sender);
+    defer std.heap.page_allocator.free(parsed_tx.receiver);
+    defer if (parsed_tx.evm_data) |d| std.heap.page_allocator.free(d);
 
     // 4. Assertions
     // Using expectEqualStrings for direct comparison. Assumes null termination or exact length match.


### PR DESCRIPTION
## 概要

Zen本「Zig言語で学ぶブロックチェイン」の対になる本リポジトリで、`src/p2p.zig` のテストが **zig 0.14.0 でコンパイル/実行できない**問題を修正し、Zig バージョンを `.mise.toml` で固定しました。

これらのテストは `main.zig` を起点とする CI (`zig build test`) では実行されないため（`root.zig`/`main.zig` から `refAllDecls` されない）、潜在バグが見逃されていました。`zig test src/p2p.zig` で単体実行すると顕在化します。

## 修正内容

### `src/p2p.zig` テスト修正（潜在バグ4種）
1. **存在しない `std.io.StreamSource{ .reader, .writer }` でのモック** → `sendEvmTx` を `writer: anytype` を受け取る**依存性注入**に変更し、`MockStreamWriter` で出力を検証できるようにした（呼び出し側3箇所も `peer.stream.writer(), peer.address` を渡す形に更新）。
2. **`ArrayList.pop()` が `?T` を返す点に未対応**（0.14変更）→ optional 捕捉ループ `while (queue.pop()) |item| { ... }` に修正。
3. **`tx.evm_data` を使用前に解放する use-after-free** → `defer` 化（テスト1・2の両方）。
4. **クロスアロケータ free**（segfault要因）→ グローバル `pending_evm_txs` と `parseTransactionJson` の戻り値は `page_allocator` 所有だが `testing.allocator` で解放していたため、`page_allocator` に統一。

### `.mise.toml` 追加
- CI (`.github/workflows/ci.yml`, `setup-zig@v2 version: 0.14.0`) と一致する `zig = "0.14.0"` を固定。

## 検証（zig 0.14.0）

- `zig test src/p2p.zig` → **All 2 tests passed**
- `zig test src/main.zig` → All 3 tests passed（呼び出し側整合）
- `zig fmt --check src/p2p.zig` → 差分なし

補足: macOS 26 系では zig 0.14.0 のネイティブリンクが libSystem スタブ未対応で失敗するため、検証は `-target aarch64-macos.15.0.0` を付与して実施しています（`zig build` のビルドランナー自体は native リンクのため当該環境では不可）。Linux CI には影響しません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
