### PR TITLE
🐛 修正(references): ハッシュ表示を{x:0>2}に統一・step4-2難易度ドリフト補正

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,26 @@
 - Docker (optional): `docker compose up -d` then `docker exec -it node2 sh` to interact. If you change binary name/flags, update `docker-compose.yml` accordingly.
  - Enable hooks: `git config core.hooksPath .githooks` (pre-commit enforces `zig fmt --check`).
 
+## `references/` = 書籍の章・段階別「正解コード」（重要）
+このリポジトリは書籍「Zig言語で学ぶブロックチェイン」(別リポジトリ `zenn-article/books/zig-blockchain`) と対になっており、`references/` に各章・各段階の完成コードが入っています。エージェントは作業前にこの対応を理解すること。
+
+- 構成: `chapter2/ chapter3/(step1-5) chapter4/(step1-3) chapter5/ chapter6/(step1-2, nodeA/nodeB) chapter7/ chapter8/ chapter9/ EVMchapter/`。各ディレクトリは**自己完結**で `build.zig` を持ち、多くが専用の `Dockerfile`/`docker-compose.yml` 付き（`CMD ["zig","build","run"]`）。
+- `EVMchapter/src/` は最終 `src/` と**ほぼ同一**（EVM章＝書籍 ch9-14 の正解は最終 src と同じ）。
+- `references/books/` は本の**旧ドラフト**（`chapter9_new.md` 等）。権威は `zenn-article/books/zig-blockchain/`。
+- **章番号はオフセットする**: 参照の番号は書籍の章番号と一致しない（例: `references/chapter3/step4`・`step4-2` が書籍 ch4 の2ブロックに対応、`references/chapter5` が書籍 ch5）。対応は各 `main.zig` の genesis(data/transactions/difficulty) と書籍のログを突き合わせて確定すること。
+- 難易度は `mineBlock(&block, N)` の N（先頭 N バイトが 0 になるまで採掘）。書籍本文の「先頭 N バイト00」と一致させる。
+
+### 書籍のログを実出力に再生成する手順
+1. 対象章の参照でハッシュ表示が `{x}` なら `{x:0>2}` に直す（`{x}` は0埋めされず64桁未満になる）。
+2. docker で決定的な実値を得る（ホストの `.zig-cache` 混入を避けるためマウント無しで）:
+   `cd references/chapterX[/stepY] && docker build -t t . && docker run --rm t`
+3. 出力の `Nonce`/`Hash`/`Timestamp` を書籍の該当ログにそのまま反映（手でパディングしない）。
+
+## macOS でのビルド注意（zig 0.14.0）
+- macOS 26 系ではネイティブの `zig build`/`zig test` が libSystem スタブ未対応でリンク失敗する。回避は OS バージョンを完全指定でピン: `zig test src/<file>.zig -target aarch64-macos.15.0.0`（生成物は macOS 26 でも実行可）。
+- `zig build` はビルドランナー自体が native リンクのため当該環境では不可 → **docker（Alpine, linux/amd64）を使う**。
+- 補足: CI (`zig build test`) は `main.zig`/`root.zig` 起点のため、`refAllDecls` されない各ファイル内テストは実行されない。ファイル単体の検証は `zig test src/<file>.zig -target aarch64-macos.15.0.0` を使う。
+
 ## Coding Style & Naming Conventions
 - Formatter: Always run `zig fmt` before committing.
 - Indentation: 4 spaces; no tabs.

--- a/references/chapter3/step2/src/main.zig
+++ b/references/chapter3/step2/src/main.zig
@@ -70,7 +70,7 @@ pub fn main() !void {
     try stdout.print("Hash       : ", .{});
     // 32バイトのハッシュを1バイトずつ16進数（小文字）で出力する
     for (genesis_block.hash) |byte| {
-        try stdout.print("{x}", .{byte});
+        try stdout.print("{x:0>2}", .{byte});
     }
     try stdout.print("\n", .{});
 }

--- a/references/chapter3/step3/src/main.zig
+++ b/references/chapter3/step3/src/main.zig
@@ -108,7 +108,7 @@ pub fn main() !void {
     try stdout.print("Hash       : ", .{}); // ← ここはプレースホルダなし、引数なし
     // 32バイトのハッシュを1バイトずつ16進数で出力
     for (genesis_block.hash) |byte| {
-        try stdout.print("{x}", .{byte});
+        try stdout.print("{x:0>2}", .{byte});
     }
     try stdout.print("\n", .{});
 }

--- a/references/chapter3/step4-2/src/main.zig
+++ b/references/chapter3/step4-2/src/main.zig
@@ -230,7 +230,7 @@ pub fn main() !void {
     // ブロックの初期ハッシュを計算
     genesis_block.hash = calculateHash(&genesis_block);
     // 難易度 1(先頭1バイトが 0)になるまで nonce を探索する
-    mineBlock(&genesis_block, 1);
+    mineBlock(&genesis_block, 2);
 
     // 結果を標準出力に表示
     try stdout.print("Block index: {d}\n", .{genesis_block.index});
@@ -243,7 +243,7 @@ pub fn main() !void {
     }
     try stdout.print("Hash       : ", .{});
     for (genesis_block.hash) |byte| {
-        try stdout.print("{x}", .{byte});
+        try stdout.print("{x:0>2}", .{byte});
     }
     try stdout.print("\n", .{});
 }

--- a/references/chapter3/step4/src/main.zig
+++ b/references/chapter3/step4/src/main.zig
@@ -111,7 +111,7 @@ pub fn main() !void {
     try stdout.print("Hash       : ", .{}); // ← ここはプレースホルダなし、引数なし
     // 32バイトのハッシュを1バイトずつ16進数で出力
     for (genesis_block.hash) |byte| {
-        try stdout.print("{x}", .{byte});
+        try stdout.print("{x:0>2}", .{byte});
     }
     try stdout.print("\n", .{});
 }

--- a/references/chapter5/src/main.zig
+++ b/references/chapter5/src/main.zig
@@ -56,7 +56,7 @@ pub fn main() !void {
     }
     try stdout.print("Hash       : ", .{});
     for (genesis_block.hash) |byte| {
-        try stdout.print("{x}", .{byte});
+        try stdout.print("{x:0>2}", .{byte});
     }
     try stdout.print("\n", .{});
 }


### PR DESCRIPTION
書籍「Zig言語で学ぶブロックチェイン」のログを実出力に再生成する過程(zenn-article #236/#245)で判明した参照コードの不整合を修正。

- `chapter5` / `chapter3/step4` / `chapter3/step4-2` のハッシュ表示 `{x}`→`{x:0>2}`（0埋めされず64桁未満になる問題）。
- `chapter3/step4-2` の `mineBlock` 難易度が 1 にドリフトしていたのを、書籍本文『先頭2バイト00 00』に合わせ 2 に補正（難易度2の決定的実出力: nonce=30572, hash=0000ea12...）。

docker(Alpine, zig 0.14.0)でビルド・実行し実値確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)