### PR TITLE
🐛 修正(references): 残る採掘参照のハッシュ表示を{x:0>2}に統一 (#245)

### DIFF
--- a/references/chapter3/step5/src/main.zig
+++ b/references/chapter3/step5/src/main.zig
@@ -285,7 +285,7 @@ pub fn main() !void {
     }
     try stdout.print("Hash       : ", .{});
     for (genesis_block.hash) |byte| {
-        try stdout.print("{x}", .{byte});
+        try stdout.print("{x:0>2}", .{byte});
     }
     try stdout.print("\n", .{});
 }

--- a/references/chapter4/step1/src/main.zig
+++ b/references/chapter4/step1/src/main.zig
@@ -111,7 +111,7 @@ pub fn main() !void {
     try stdout.print("Hash       : ", .{}); // ← ここはプレースホルダなし、引数なし
     // 32バイトのハッシュを1バイトずつ16進数で出力
     for (genesis_block.hash) |byte| {
-        try stdout.print("{x}", .{byte});
+        try stdout.print("{x:0>2}", .{byte});
     }
     try stdout.print("\n", .{});
 }

--- a/references/chapter4/step2/src/main.zig
+++ b/references/chapter4/step2/src/main.zig
@@ -243,7 +243,7 @@ pub fn main() !void {
     }
     try stdout.print("Hash       : ", .{});
     for (genesis_block.hash) |byte| {
-        try stdout.print("{x}", .{byte});
+        try stdout.print("{x:0>2}", .{byte});
     }
     try stdout.print("\n", .{});
 }

--- a/references/chapter4/step3/src/main.zig
+++ b/references/chapter4/step3/src/main.zig
@@ -243,7 +243,7 @@ pub fn main() !void {
     }
     try stdout.print("Hash       : ", .{});
     for (genesis_block.hash) |byte| {
-        try stdout.print("{x}", .{byte});
+        try stdout.print("{x:0>2}", .{byte});
     }
     try stdout.print("\n", .{});
 }


### PR DESCRIPTION
`chapter3/step5`, `chapter4/step1-3` のハッシュ出力 `{x}`→`{x:0>2}`。これで references 配下の採掘出力が全て0埋め2桁(64桁)で統一されます（zenn-article #245 の残タスク）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)